### PR TITLE
Cookie and DB SSL

### DIFF
--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -101,7 +101,7 @@ func generateToken(user *user.User, expirationTime time.Time, secret []byte) (st
 // Here we are creating a new cookie, which will store the valid JWT token.
 func setTokenCookie(name, token string, expiration time.Time, c echo.Context) {
 	// Get optional cookie domain name
-	cookieDomain := os.Getenv("FRONTEND_HOST")
+	cookieDomain := os.Getenv("COOKIE_DOMAIN")
 	cookie := new(http.Cookie)
 	cookie.Name = name
 	cookie.Value = token

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -100,6 +100,8 @@ func generateToken(user *user.User, expirationTime time.Time, secret []byte) (st
 
 // Here we are creating a new cookie, which will store the valid JWT token.
 func setTokenCookie(name, token string, expiration time.Time, c echo.Context) {
+	// Get optional cookie domain name
+	cookieDomain := os.Getenv("FRONTEND_HOST")
 	cookie := new(http.Cookie)
 	cookie.Name = name
 	cookie.Value = token
@@ -108,6 +110,9 @@ func setTokenCookie(name, token string, expiration time.Time, c echo.Context) {
 	// Http-only helps mitigate the risk of client side script accessing the protected cookie.
 	cookie.HttpOnly = false
 	cookie.SameSite = http.SameSiteLaxMode
+	if cookieDomain != "" {
+		cookie.Domain = cookieDomain
+	}
 
 	c.SetCookie(cookie)
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -25,9 +25,10 @@ func NewDatabase() (*Database, error) {
 	dbPass := os.Getenv("DB_PASS")
 	dbName := os.Getenv("DB_NAME")
 	dbSSL := os.Getenv("DB_SSL")
+	dbSSLTRootCert := os.Getenv("DB_SSL_ROOT_CERT")
 
-	connectionString := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
-		dbHost, dbPort, dbUser, dbPass, dbName, dbSSL)
+	connectionString := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s sslrootcert=%s",
+		dbHost, dbPort, dbUser, dbPass, dbName, dbSSL, dbSSLTRootCert)
 
 	client, err := ent.Open("postgres", connectionString)
 


### PR DESCRIPTION
Add a new ENV var named `COOKIE_DOMAIN`. This helpful when deploying Ganymede behind a reverse proxy using different subdomains for each service. Setting the `COOKIE_DOMAIN` to the root subdomain for Ganymede will solve the cookie issues.

Add support for database SSL root certs. Valid options for `DB_SSL` include:

- disable - No SSL
- require - Always SSL (skip verification)
- verify-ca - Always SSL (verify that the certificate presented by the server was signed by a trusted CA)
- verify-full - Always SSL (verify that the certification presented by the server was signed by a trusted CA and the server host name matches the one in the certificate)

If `DB_SSL` is *not* set to disable, then the ENV var `DB_SSL_ROOT_CERT` needs to point to a DB ssl root cert.