### PR TITLE
fix(archive): continue live video post-process if no chat

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -631,7 +631,9 @@ func (s *Service) TaskLiveVideoDownload(ch *ent.Channel, v *ent.Vod, q *ent.Queu
 	}
 
 	// Send kill command to chat download
-	busC <- true
+	if q.TaskChatDownload != utils.Success {
+		busC <- true
+	}
 
 	q.Update().SetTaskVideoDownload(utils.Success).SaveX(context.Background())
 


### PR DESCRIPTION
When live archiving with the chat option disabled, the post-process of the live video would fail. This is because it attempted to kill the chat downloader when it wasn't running. Added a check to see if the chat download task is not complete.