### PR TITLE
Changes for Twitch Downloader v1.50.4

### DIFF
--- a/internal/transport/http/handler.go
+++ b/internal/transport/http/handler.go
@@ -186,6 +186,7 @@ func groupV1Routes(e *echo.Group, h *Handler) {
 	liveGroup.PUT("/:id", h.UpdateLiveWatchedChannel, authMiddleware, auth.GetUserMiddleware, auth.UserRoleMiddleware(utils.EditorRole))
 	liveGroup.DELETE("/:id", h.DeleteLiveWatchedChannel, authMiddleware, auth.GetUserMiddleware, auth.UserRoleMiddleware(utils.EditorRole))
 	liveGroup.GET("/check", h.Check, authMiddleware, auth.GetUserMiddleware, auth.UserRoleMiddleware(utils.EditorRole))
+	liveGroup.POST("/chat-convert", h.ConvertChat, authMiddleware, auth.GetUserMiddleware, auth.UserRoleMiddleware(utils.EditorRole))
 
 	// Playback
 	playbackGroup := e.Group("/playback")

--- a/internal/utils/chat.go
+++ b/internal/utils/chat.go
@@ -174,7 +174,7 @@ func ConvertTwitchLiveChatToVodChat(path string, channelName string, vID string,
 			Fragments: []Fragment{
 				Fragment{
 					Text:     "Initial chat message",
-					Emoticon: &Emoticon{},
+					Emoticon: nil,
 					Pos1:     0,
 					Pos2:     0,
 				},
@@ -281,7 +281,7 @@ func ConvertTwitchLiveChatToVodChat(path string, channelName string, vID string,
 				fragmentText := parsedComment.Message.Body[:emoteFragment.Pos1]
 				fragment := Fragment{
 					Text:     fragmentText,
-					Emoticon: &Emoticon{},
+					Emoticon: nil,
 				}
 				formattedEmoteFragments = append(formattedEmoteFragments, fragment)
 				formattedEmoteFragments = append(formattedEmoteFragments, emoteFragment)
@@ -289,7 +289,7 @@ func ConvertTwitchLiveChatToVodChat(path string, channelName string, vID string,
 				fragmentText := parsedComment.Message.Body[emoteFragments[i-1].Pos2:emoteFragment.Pos1]
 				fragment := Fragment{
 					Text:     fragmentText,
-					Emoticon: &Emoticon{},
+					Emoticon: nil,
 				}
 				formattedEmoteFragments = append(formattedEmoteFragments, fragment)
 				formattedEmoteFragments = append(formattedEmoteFragments, emoteFragment)
@@ -303,7 +303,7 @@ func ConvertTwitchLiveChatToVodChat(path string, channelName string, vID string,
 				fragmentText := parsedComment.Message.Body[formattedEmoteFragments[lastItem].Pos2:]
 				fragment := Fragment{
 					Text:     fragmentText,
-					Emoticon: &Emoticon{},
+					Emoticon: nil,
 				}
 				formattedEmoteFragments = append(formattedEmoteFragments, fragment)
 			}
@@ -320,7 +320,7 @@ func ConvertTwitchLiveChatToVodChat(path string, channelName string, vID string,
 			for _, liveBadge := range liveComment.Author.Badges {
 				userBadge := UserBadge{
 					ID:      liveBadge.Name,
-					Version: liveBadge.Version,
+					Version: string(rune(liveBadge.Version)),
 				}
 				parsedComment.Message.UserBadges = append(parsedComment.Message.UserBadges, userBadge)
 			}

--- a/internal/utils/chat.go
+++ b/internal/utils/chat.go
@@ -57,7 +57,7 @@ type Fragment struct {
 
 type UserBadge struct {
 	ID      string `json:"_id"`
-	Version int    `json:"version"`
+	Version string `json:"version"`
 }
 
 type UserNoticParams struct {


### PR DESCRIPTION
Twitch Downloader v1.50.4 broke the Live VOD chat to VOD chat conversion function. This PR changes the following:
- Badge version is now saved as a string (was an int).
- Empty emoticon fragments are now `null` rather than `{ "emoticon_id": "", "emoticon_set_id": "" }`

Also added a `chat-conversion` HTTP endpoint for rapid testing the conversion function.

These are all the issues I found immediately. I will merge this request and perform more tests from master.