### PR TITLE
fix(streamlink): Twitch Embedded Ads

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -141,8 +141,21 @@ func ConvertTwitchVodVideo(v *ent.Vod) error {
 }
 
 func DownloadTwitchLiveVideo(v *ent.Vod, ch *ent.Channel) error {
-
-	cmd := osExec.Command("streamlink", fmt.Sprintf("https://twitch.tv/%s", ch.Name), fmt.Sprintf("%s,best", v.Resolution), "--force-progress", "--force", "--twitch-low-latency", "--twitch-disable-ads", "--twitch-disable-hosting", "-o", fmt.Sprintf("/tmp/%s_%s-video.mp4", v.ExtID, v.ID))
+	// Fetch config params
+	liveStreamlinkParams := viper.GetString("parameters.streamlink_live")
+	// Split supplied params into array
+	arr := strings.Fields(liveStreamlinkParams)
+	// Generate args for exec
+	argArr := []string{fmt.Sprintf("https://twitch.tv/%s", ch.Name), fmt.Sprintf("%s,best", v.Resolution)}
+	// add each config param to arg
+	for _, v := range arr {
+		argArr = append(argArr, v)
+	}
+	// add output file
+	argArr = append(argArr, "-o", fmt.Sprintf("/tmp/%s_%s-video.mp4", v.ExtID, v.ID))
+	log.Debug().Msgf("streamlink live args: %v", argArr)
+	// Execute streamlink
+	cmd := osExec.Command("streamlink", argArr...)
 
 	videoLogfile, err := os.Create(fmt.Sprintf("/logs/%s_%s-video.log", v.ExtID, v.ID))
 	if err != nil {

--- a/internal/transport/http/config.go
+++ b/internal/transport/http/config.go
@@ -16,8 +16,9 @@ type UpdateConfigRequest struct {
 	WebhookURL          string `json:"webhook_url"`
 	DBSeeded            bool   `json:"db_seeded"`
 	Parameters          struct {
-		VideoConvert string `json:"video_convert" validate:"required"`
-		ChatRender   string `json:"chat_render" validate:"required"`
+		VideoConvert   string `json:"video_convert" validate:"required"`
+		ChatRender     string `json:"chat_render" validate:"required"`
+		StreamlinkLive string `json:"streamlink_live"`
 	} `json:"parameters"`
 }
 
@@ -42,8 +43,9 @@ func (h *Handler) UpdateConfig(c echo.Context) error {
 		WebhookURL:          conf.WebhookURL,
 		DBSeeded:            conf.DBSeeded,
 		Parameters: struct {
-			VideoConvert string `json:"video_convert"`
-			ChatRender   string `json:"chat_render"`
+			VideoConvert   string `json:"video_convert"`
+			ChatRender     string `json:"chat_render"`
+			StreamlinkLive string `json:"streamlink_live"`
 		}(conf.Parameters),
 	}
 	if err := h.Service.ConfigService.UpdateConfig(c, &cDto); err != nil {


### PR DESCRIPTION
For https://github.com/Zibbp/ganymede/issues/57

This PR add a new entry in `config.json` named `streamlink_live`. This allows the modification of Streamlink arguments **only** for live streams / live archives by the user.

The `DownloadTwitchLiveVideo` exec function now reads those arguments and uses them.