### PR TITLE
"Render Chat" Options

### DIFF
--- a/ent/live.go
+++ b/ent/live.go
@@ -36,6 +36,8 @@ type Live struct {
 	Resolution string `json:"resolution,omitempty"`
 	// The time the channel last went live.
 	LastLive time.Time `json:"last_live,omitempty"`
+	// Whether the chat should be rendered.
+	RenderChat bool `json:"render_chat,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
@@ -73,7 +75,7 @@ func (*Live) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case live.FieldWatchLive, live.FieldWatchVod, live.FieldDownloadArchives, live.FieldDownloadHighlights, live.FieldDownloadUploads, live.FieldIsLive, live.FieldArchiveChat:
+		case live.FieldWatchLive, live.FieldWatchVod, live.FieldDownloadArchives, live.FieldDownloadHighlights, live.FieldDownloadUploads, live.FieldIsLive, live.FieldArchiveChat, live.FieldRenderChat:
 			values[i] = new(sql.NullBool)
 		case live.FieldResolution:
 			values[i] = new(sql.NullString)
@@ -158,6 +160,12 @@ func (l *Live) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				l.LastLive = value.Time
 			}
+		case live.FieldRenderChat:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field render_chat", values[i])
+			} else if value.Valid {
+				l.RenderChat = value.Bool
+			}
 		case live.FieldUpdatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field updated_at", values[i])
@@ -236,6 +244,9 @@ func (l *Live) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("last_live=")
 	builder.WriteString(l.LastLive.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("render_chat=")
+	builder.WriteString(fmt.Sprintf("%v", l.RenderChat))
 	builder.WriteString(", ")
 	builder.WriteString("updated_at=")
 	builder.WriteString(l.UpdatedAt.Format(time.ANSIC))

--- a/ent/live/live.go
+++ b/ent/live/live.go
@@ -31,6 +31,8 @@ const (
 	FieldResolution = "resolution"
 	// FieldLastLive holds the string denoting the last_live field in the database.
 	FieldLastLive = "last_live"
+	// FieldRenderChat holds the string denoting the render_chat field in the database.
+	FieldRenderChat = "render_chat"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
 	FieldUpdatedAt = "updated_at"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
@@ -60,6 +62,7 @@ var Columns = []string{
 	FieldArchiveChat,
 	FieldResolution,
 	FieldLastLive,
+	FieldRenderChat,
 	FieldUpdatedAt,
 	FieldCreatedAt,
 }
@@ -104,6 +107,8 @@ var (
 	DefaultResolution string
 	// DefaultLastLive holds the default value on creation for the "last_live" field.
 	DefaultLastLive func() time.Time
+	// DefaultRenderChat holds the default value on creation for the "render_chat" field.
+	DefaultRenderChat bool
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
 	DefaultUpdatedAt func() time.Time
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.

--- a/ent/live/where.go
+++ b/ent/live/where.go
@@ -101,6 +101,11 @@ func LastLive(v time.Time) predicate.Live {
 	return predicate.Live(sql.FieldEQ(FieldLastLive, v))
 }
 
+// RenderChat applies equality check predicate on the "render_chat" field. It's identical to RenderChatEQ.
+func RenderChat(v bool) predicate.Live {
+	return predicate.Live(sql.FieldEQ(FieldRenderChat, v))
+}
+
 // UpdatedAt applies equality check predicate on the "updated_at" field. It's identical to UpdatedAtEQ.
 func UpdatedAt(v time.Time) predicate.Live {
 	return predicate.Live(sql.FieldEQ(FieldUpdatedAt, v))
@@ -294,6 +299,16 @@ func LastLiveLT(v time.Time) predicate.Live {
 // LastLiveLTE applies the LTE predicate on the "last_live" field.
 func LastLiveLTE(v time.Time) predicate.Live {
 	return predicate.Live(sql.FieldLTE(FieldLastLive, v))
+}
+
+// RenderChatEQ applies the EQ predicate on the "render_chat" field.
+func RenderChatEQ(v bool) predicate.Live {
+	return predicate.Live(sql.FieldEQ(FieldRenderChat, v))
+}
+
+// RenderChatNEQ applies the NEQ predicate on the "render_chat" field.
+func RenderChatNEQ(v bool) predicate.Live {
+	return predicate.Live(sql.FieldNEQ(FieldRenderChat, v))
 }
 
 // UpdatedAtEQ applies the EQ predicate on the "updated_at" field.

--- a/ent/live_create.go
+++ b/ent/live_create.go
@@ -148,6 +148,20 @@ func (lc *LiveCreate) SetNillableLastLive(t *time.Time) *LiveCreate {
 	return lc
 }
 
+// SetRenderChat sets the "render_chat" field.
+func (lc *LiveCreate) SetRenderChat(b bool) *LiveCreate {
+	lc.mutation.SetRenderChat(b)
+	return lc
+}
+
+// SetNillableRenderChat sets the "render_chat" field if the given value is not nil.
+func (lc *LiveCreate) SetNillableRenderChat(b *bool) *LiveCreate {
+	if b != nil {
+		lc.SetRenderChat(*b)
+	}
+	return lc
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (lc *LiveCreate) SetUpdatedAt(t time.Time) *LiveCreate {
 	lc.mutation.SetUpdatedAt(t)
@@ -272,6 +286,10 @@ func (lc *LiveCreate) defaults() {
 		v := live.DefaultLastLive()
 		lc.mutation.SetLastLive(v)
 	}
+	if _, ok := lc.mutation.RenderChat(); !ok {
+		v := live.DefaultRenderChat
+		lc.mutation.SetRenderChat(v)
+	}
 	if _, ok := lc.mutation.UpdatedAt(); !ok {
 		v := live.DefaultUpdatedAt()
 		lc.mutation.SetUpdatedAt(v)
@@ -311,6 +329,9 @@ func (lc *LiveCreate) check() error {
 	}
 	if _, ok := lc.mutation.LastLive(); !ok {
 		return &ValidationError{Name: "last_live", err: errors.New(`ent: missing required field "Live.last_live"`)}
+	}
+	if _, ok := lc.mutation.RenderChat(); !ok {
+		return &ValidationError{Name: "render_chat", err: errors.New(`ent: missing required field "Live.render_chat"`)}
 	}
 	if _, ok := lc.mutation.UpdatedAt(); !ok {
 		return &ValidationError{Name: "updated_at", err: errors.New(`ent: missing required field "Live.updated_at"`)}
@@ -397,6 +418,10 @@ func (lc *LiveCreate) createSpec() (*Live, *sqlgraph.CreateSpec) {
 	if value, ok := lc.mutation.LastLive(); ok {
 		_spec.SetField(live.FieldLastLive, field.TypeTime, value)
 		_node.LastLive = value
+	}
+	if value, ok := lc.mutation.RenderChat(); ok {
+		_spec.SetField(live.FieldRenderChat, field.TypeBool, value)
+		_node.RenderChat = value
 	}
 	if value, ok := lc.mutation.UpdatedAt(); ok {
 		_spec.SetField(live.FieldUpdatedAt, field.TypeTime, value)

--- a/ent/live_update.go
+++ b/ent/live_update.go
@@ -162,6 +162,20 @@ func (lu *LiveUpdate) SetNillableLastLive(t *time.Time) *LiveUpdate {
 	return lu
 }
 
+// SetRenderChat sets the "render_chat" field.
+func (lu *LiveUpdate) SetRenderChat(b bool) *LiveUpdate {
+	lu.mutation.SetRenderChat(b)
+	return lu
+}
+
+// SetNillableRenderChat sets the "render_chat" field if the given value is not nil.
+func (lu *LiveUpdate) SetNillableRenderChat(b *bool) *LiveUpdate {
+	if b != nil {
+		lu.SetRenderChat(*b)
+	}
+	return lu
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (lu *LiveUpdate) SetUpdatedAt(t time.Time) *LiveUpdate {
 	lu.mutation.SetUpdatedAt(t)
@@ -284,6 +298,9 @@ func (lu *LiveUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := lu.mutation.LastLive(); ok {
 		_spec.SetField(live.FieldLastLive, field.TypeTime, value)
+	}
+	if value, ok := lu.mutation.RenderChat(); ok {
+		_spec.SetField(live.FieldRenderChat, field.TypeBool, value)
 	}
 	if value, ok := lu.mutation.UpdatedAt(); ok {
 		_spec.SetField(live.FieldUpdatedAt, field.TypeTime, value)
@@ -475,6 +492,20 @@ func (luo *LiveUpdateOne) SetNillableLastLive(t *time.Time) *LiveUpdateOne {
 	return luo
 }
 
+// SetRenderChat sets the "render_chat" field.
+func (luo *LiveUpdateOne) SetRenderChat(b bool) *LiveUpdateOne {
+	luo.mutation.SetRenderChat(b)
+	return luo
+}
+
+// SetNillableRenderChat sets the "render_chat" field if the given value is not nil.
+func (luo *LiveUpdateOne) SetNillableRenderChat(b *bool) *LiveUpdateOne {
+	if b != nil {
+		luo.SetRenderChat(*b)
+	}
+	return luo
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (luo *LiveUpdateOne) SetUpdatedAt(t time.Time) *LiveUpdateOne {
 	luo.mutation.SetUpdatedAt(t)
@@ -621,6 +652,9 @@ func (luo *LiveUpdateOne) sqlSave(ctx context.Context) (_node *Live, err error) 
 	}
 	if value, ok := luo.mutation.LastLive(); ok {
 		_spec.SetField(live.FieldLastLive, field.TypeTime, value)
+	}
+	if value, ok := luo.mutation.RenderChat(); ok {
+		_spec.SetField(live.FieldRenderChat, field.TypeBool, value)
 	}
 	if value, ok := luo.mutation.UpdatedAt(); ok {
 		_spec.SetField(live.FieldUpdatedAt, field.TypeTime, value)

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -36,6 +36,7 @@ var (
 		{Name: "archive_chat", Type: field.TypeBool, Default: true},
 		{Name: "resolution", Type: field.TypeString, Nullable: true, Default: "best"},
 		{Name: "last_live", Type: field.TypeTime},
+		{Name: "render_chat", Type: field.TypeBool, Default: true},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "channel_live", Type: field.TypeUUID},
@@ -48,7 +49,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "lives_channels_live",
-				Columns:    []*schema.Column{LivesColumns[12]},
+				Columns:    []*schema.Column{LivesColumns[13]},
 				RefColumns: []*schema.Column{ChannelsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -104,6 +105,7 @@ var (
 		{Name: "task_chat_render", Type: field.TypeEnum, Nullable: true, Enums: []string{"success", "running", "pending", "failed"}, Default: "pending"},
 		{Name: "task_chat_move", Type: field.TypeEnum, Nullable: true, Enums: []string{"success", "running", "pending", "failed"}, Default: "pending"},
 		{Name: "chat_start", Type: field.TypeTime, Nullable: true},
+		{Name: "render_chat", Type: field.TypeBool, Nullable: true, Default: true},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "vod_queue", Type: field.TypeUUID, Unique: true},
@@ -116,7 +118,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "queues_vods_queue",
-				Columns:    []*schema.Column{QueuesColumns[19]},
+				Columns:    []*schema.Column{QueuesColumns[20]},
 				RefColumns: []*schema.Column{VodsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -857,6 +857,7 @@ type LiveMutation struct {
 	archive_chat        *bool
 	resolution          *string
 	last_live           *time.Time
+	render_chat         *bool
 	updated_at          *time.Time
 	created_at          *time.Time
 	clearedFields       map[string]struct{}
@@ -1308,6 +1309,42 @@ func (m *LiveMutation) ResetLastLive() {
 	m.last_live = nil
 }
 
+// SetRenderChat sets the "render_chat" field.
+func (m *LiveMutation) SetRenderChat(b bool) {
+	m.render_chat = &b
+}
+
+// RenderChat returns the value of the "render_chat" field in the mutation.
+func (m *LiveMutation) RenderChat() (r bool, exists bool) {
+	v := m.render_chat
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRenderChat returns the old "render_chat" field's value of the Live entity.
+// If the Live object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *LiveMutation) OldRenderChat(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRenderChat is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRenderChat requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRenderChat: %w", err)
+	}
+	return oldValue.RenderChat, nil
+}
+
+// ResetRenderChat resets all changes to the "render_chat" field.
+func (m *LiveMutation) ResetRenderChat() {
+	m.render_chat = nil
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (m *LiveMutation) SetUpdatedAt(t time.Time) {
 	m.updated_at = &t
@@ -1453,7 +1490,7 @@ func (m *LiveMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *LiveMutation) Fields() []string {
-	fields := make([]string, 0, 11)
+	fields := make([]string, 0, 12)
 	if m.watch_live != nil {
 		fields = append(fields, live.FieldWatchLive)
 	}
@@ -1480,6 +1517,9 @@ func (m *LiveMutation) Fields() []string {
 	}
 	if m.last_live != nil {
 		fields = append(fields, live.FieldLastLive)
+	}
+	if m.render_chat != nil {
+		fields = append(fields, live.FieldRenderChat)
 	}
 	if m.updated_at != nil {
 		fields = append(fields, live.FieldUpdatedAt)
@@ -1513,6 +1553,8 @@ func (m *LiveMutation) Field(name string) (ent.Value, bool) {
 		return m.Resolution()
 	case live.FieldLastLive:
 		return m.LastLive()
+	case live.FieldRenderChat:
+		return m.RenderChat()
 	case live.FieldUpdatedAt:
 		return m.UpdatedAt()
 	case live.FieldCreatedAt:
@@ -1544,6 +1586,8 @@ func (m *LiveMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldResolution(ctx)
 	case live.FieldLastLive:
 		return m.OldLastLive(ctx)
+	case live.FieldRenderChat:
+		return m.OldRenderChat(ctx)
 	case live.FieldUpdatedAt:
 		return m.OldUpdatedAt(ctx)
 	case live.FieldCreatedAt:
@@ -1619,6 +1663,13 @@ func (m *LiveMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetLastLive(v)
+		return nil
+	case live.FieldRenderChat:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRenderChat(v)
 		return nil
 	case live.FieldUpdatedAt:
 		v, ok := value.(time.Time)
@@ -1718,6 +1769,9 @@ func (m *LiveMutation) ResetField(name string) error {
 		return nil
 	case live.FieldLastLive:
 		m.ResetLastLive()
+		return nil
+	case live.FieldRenderChat:
+		m.ResetRenderChat()
 		return nil
 	case live.FieldUpdatedAt:
 		m.ResetUpdatedAt()
@@ -3167,6 +3221,7 @@ type QueueMutation struct {
 	task_chat_render            *utils.TaskStatus
 	task_chat_move              *utils.TaskStatus
 	chat_start                  *time.Time
+	render_chat                 *bool
 	updated_at                  *time.Time
 	created_at                  *time.Time
 	clearedFields               map[string]struct{}
@@ -4000,6 +4055,55 @@ func (m *QueueMutation) ResetChatStart() {
 	delete(m.clearedFields, queue.FieldChatStart)
 }
 
+// SetRenderChat sets the "render_chat" field.
+func (m *QueueMutation) SetRenderChat(b bool) {
+	m.render_chat = &b
+}
+
+// RenderChat returns the value of the "render_chat" field in the mutation.
+func (m *QueueMutation) RenderChat() (r bool, exists bool) {
+	v := m.render_chat
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRenderChat returns the old "render_chat" field's value of the Queue entity.
+// If the Queue object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *QueueMutation) OldRenderChat(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRenderChat is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRenderChat requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRenderChat: %w", err)
+	}
+	return oldValue.RenderChat, nil
+}
+
+// ClearRenderChat clears the value of the "render_chat" field.
+func (m *QueueMutation) ClearRenderChat() {
+	m.render_chat = nil
+	m.clearedFields[queue.FieldRenderChat] = struct{}{}
+}
+
+// RenderChatCleared returns if the "render_chat" field was cleared in this mutation.
+func (m *QueueMutation) RenderChatCleared() bool {
+	_, ok := m.clearedFields[queue.FieldRenderChat]
+	return ok
+}
+
+// ResetRenderChat resets all changes to the "render_chat" field.
+func (m *QueueMutation) ResetRenderChat() {
+	m.render_chat = nil
+	delete(m.clearedFields, queue.FieldRenderChat)
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (m *QueueMutation) SetUpdatedAt(t time.Time) {
 	m.updated_at = &t
@@ -4145,7 +4249,7 @@ func (m *QueueMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *QueueMutation) Fields() []string {
-	fields := make([]string, 0, 18)
+	fields := make([]string, 0, 19)
 	if m.live_archive != nil {
 		fields = append(fields, queue.FieldLiveArchive)
 	}
@@ -4194,6 +4298,9 @@ func (m *QueueMutation) Fields() []string {
 	if m.chat_start != nil {
 		fields = append(fields, queue.FieldChatStart)
 	}
+	if m.render_chat != nil {
+		fields = append(fields, queue.FieldRenderChat)
+	}
 	if m.updated_at != nil {
 		fields = append(fields, queue.FieldUpdatedAt)
 	}
@@ -4240,6 +4347,8 @@ func (m *QueueMutation) Field(name string) (ent.Value, bool) {
 		return m.TaskChatMove()
 	case queue.FieldChatStart:
 		return m.ChatStart()
+	case queue.FieldRenderChat:
+		return m.RenderChat()
 	case queue.FieldUpdatedAt:
 		return m.UpdatedAt()
 	case queue.FieldCreatedAt:
@@ -4285,6 +4394,8 @@ func (m *QueueMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldTaskChatMove(ctx)
 	case queue.FieldChatStart:
 		return m.OldChatStart(ctx)
+	case queue.FieldRenderChat:
+		return m.OldRenderChat(ctx)
 	case queue.FieldUpdatedAt:
 		return m.OldUpdatedAt(ctx)
 	case queue.FieldCreatedAt:
@@ -4410,6 +4521,13 @@ func (m *QueueMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetChatStart(v)
 		return nil
+	case queue.FieldRenderChat:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRenderChat(v)
+		return nil
 	case queue.FieldUpdatedAt:
 		v, ok := value.(time.Time)
 		if !ok {
@@ -4487,6 +4605,9 @@ func (m *QueueMutation) ClearedFields() []string {
 	if m.FieldCleared(queue.FieldChatStart) {
 		fields = append(fields, queue.FieldChatStart)
 	}
+	if m.FieldCleared(queue.FieldRenderChat) {
+		fields = append(fields, queue.FieldRenderChat)
+	}
 	return fields
 }
 
@@ -4533,6 +4654,9 @@ func (m *QueueMutation) ClearField(name string) error {
 		return nil
 	case queue.FieldChatStart:
 		m.ClearChatStart()
+		return nil
+	case queue.FieldRenderChat:
+		m.ClearRenderChat()
 		return nil
 	}
 	return fmt.Errorf("unknown Queue nullable field %s", name)
@@ -4589,6 +4713,9 @@ func (m *QueueMutation) ResetField(name string) error {
 		return nil
 	case queue.FieldChatStart:
 		m.ResetChatStart()
+		return nil
+	case queue.FieldRenderChat:
+		m.ResetRenderChat()
 		return nil
 	case queue.FieldUpdatedAt:
 		m.ResetUpdatedAt()

--- a/ent/queue.go
+++ b/ent/queue.go
@@ -51,6 +51,8 @@ type Queue struct {
 	TaskChatMove utils.TaskStatus `json:"task_chat_move,omitempty"`
 	// ChatStart holds the value of the "chat_start" field.
 	ChatStart time.Time `json:"chat_start,omitempty"`
+	// RenderChat holds the value of the "render_chat" field.
+	RenderChat bool `json:"render_chat,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
@@ -88,7 +90,7 @@ func (*Queue) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case queue.FieldLiveArchive, queue.FieldOnHold, queue.FieldVideoProcessing, queue.FieldChatProcessing, queue.FieldProcessing:
+		case queue.FieldLiveArchive, queue.FieldOnHold, queue.FieldVideoProcessing, queue.FieldChatProcessing, queue.FieldProcessing, queue.FieldRenderChat:
 			values[i] = new(sql.NullBool)
 		case queue.FieldTaskVodCreateFolder, queue.FieldTaskVodDownloadThumbnail, queue.FieldTaskVodSaveInfo, queue.FieldTaskVideoDownload, queue.FieldTaskVideoConvert, queue.FieldTaskVideoMove, queue.FieldTaskChatDownload, queue.FieldTaskChatConvert, queue.FieldTaskChatRender, queue.FieldTaskChatMove:
 			values[i] = new(sql.NullString)
@@ -215,6 +217,12 @@ func (q *Queue) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				q.ChatStart = value.Time
 			}
+		case queue.FieldRenderChat:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field render_chat", values[i])
+			} else if value.Valid {
+				q.RenderChat = value.Bool
+			}
 		case queue.FieldUpdatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field updated_at", values[i])
@@ -314,6 +322,9 @@ func (q *Queue) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("chat_start=")
 	builder.WriteString(q.ChatStart.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("render_chat=")
+	builder.WriteString(fmt.Sprintf("%v", q.RenderChat))
 	builder.WriteString(", ")
 	builder.WriteString("updated_at=")
 	builder.WriteString(q.UpdatedAt.Format(time.ANSIC))

--- a/ent/queue/queue.go
+++ b/ent/queue/queue.go
@@ -47,6 +47,8 @@ const (
 	FieldTaskChatMove = "task_chat_move"
 	// FieldChatStart holds the string denoting the chat_start field in the database.
 	FieldChatStart = "chat_start"
+	// FieldRenderChat holds the string denoting the render_chat field in the database.
+	FieldRenderChat = "render_chat"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
 	FieldUpdatedAt = "updated_at"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
@@ -83,6 +85,7 @@ var Columns = []string{
 	FieldTaskChatRender,
 	FieldTaskChatMove,
 	FieldChatStart,
+	FieldRenderChat,
 	FieldUpdatedAt,
 	FieldCreatedAt,
 }
@@ -119,6 +122,8 @@ var (
 	DefaultChatProcessing bool
 	// DefaultProcessing holds the default value on creation for the "processing" field.
 	DefaultProcessing bool
+	// DefaultRenderChat holds the default value on creation for the "render_chat" field.
+	DefaultRenderChat bool
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
 	DefaultUpdatedAt func() time.Time
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.

--- a/ent/queue/where.go
+++ b/ent/queue/where.go
@@ -87,6 +87,11 @@ func ChatStart(v time.Time) predicate.Queue {
 	return predicate.Queue(sql.FieldEQ(FieldChatStart, v))
 }
 
+// RenderChat applies equality check predicate on the "render_chat" field. It's identical to RenderChatEQ.
+func RenderChat(v bool) predicate.Queue {
+	return predicate.Queue(sql.FieldEQ(FieldRenderChat, v))
+}
+
 // UpdatedAt applies equality check predicate on the "updated_at" field. It's identical to UpdatedAtEQ.
 func UpdatedAt(v time.Time) predicate.Queue {
 	return predicate.Queue(sql.FieldEQ(FieldUpdatedAt, v))
@@ -595,6 +600,26 @@ func ChatStartIsNil() predicate.Queue {
 // ChatStartNotNil applies the NotNil predicate on the "chat_start" field.
 func ChatStartNotNil() predicate.Queue {
 	return predicate.Queue(sql.FieldNotNull(FieldChatStart))
+}
+
+// RenderChatEQ applies the EQ predicate on the "render_chat" field.
+func RenderChatEQ(v bool) predicate.Queue {
+	return predicate.Queue(sql.FieldEQ(FieldRenderChat, v))
+}
+
+// RenderChatNEQ applies the NEQ predicate on the "render_chat" field.
+func RenderChatNEQ(v bool) predicate.Queue {
+	return predicate.Queue(sql.FieldNEQ(FieldRenderChat, v))
+}
+
+// RenderChatIsNil applies the IsNil predicate on the "render_chat" field.
+func RenderChatIsNil() predicate.Queue {
+	return predicate.Queue(sql.FieldIsNull(FieldRenderChat))
+}
+
+// RenderChatNotNil applies the NotNil predicate on the "render_chat" field.
+func RenderChatNotNil() predicate.Queue {
+	return predicate.Queue(sql.FieldNotNull(FieldRenderChat))
 }
 
 // UpdatedAtEQ applies the EQ predicate on the "updated_at" field.

--- a/ent/queue_create.go
+++ b/ent/queue_create.go
@@ -247,6 +247,20 @@ func (qc *QueueCreate) SetNillableChatStart(t *time.Time) *QueueCreate {
 	return qc
 }
 
+// SetRenderChat sets the "render_chat" field.
+func (qc *QueueCreate) SetRenderChat(b bool) *QueueCreate {
+	qc.mutation.SetRenderChat(b)
+	return qc
+}
+
+// SetNillableRenderChat sets the "render_chat" field if the given value is not nil.
+func (qc *QueueCreate) SetNillableRenderChat(b *bool) *QueueCreate {
+	if b != nil {
+		qc.SetRenderChat(*b)
+	}
+	return qc
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (qc *QueueCreate) SetUpdatedAt(t time.Time) *QueueCreate {
 	qc.mutation.SetUpdatedAt(t)
@@ -394,6 +408,10 @@ func (qc *QueueCreate) defaults() {
 	if _, ok := qc.mutation.TaskChatMove(); !ok {
 		v := queue.DefaultTaskChatMove
 		qc.mutation.SetTaskChatMove(v)
+	}
+	if _, ok := qc.mutation.RenderChat(); !ok {
+		v := queue.DefaultRenderChat
+		qc.mutation.SetRenderChat(v)
 	}
 	if _, ok := qc.mutation.UpdatedAt(); !ok {
 		v := queue.DefaultUpdatedAt()
@@ -589,6 +607,10 @@ func (qc *QueueCreate) createSpec() (*Queue, *sqlgraph.CreateSpec) {
 	if value, ok := qc.mutation.ChatStart(); ok {
 		_spec.SetField(queue.FieldChatStart, field.TypeTime, value)
 		_node.ChatStart = value
+	}
+	if value, ok := qc.mutation.RenderChat(); ok {
+		_spec.SetField(queue.FieldRenderChat, field.TypeBool, value)
+		_node.RenderChat = value
 	}
 	if value, ok := qc.mutation.UpdatedAt(); ok {
 		_spec.SetField(queue.FieldUpdatedAt, field.TypeTime, value)

--- a/ent/queue_update.go
+++ b/ent/queue_update.go
@@ -321,6 +321,26 @@ func (qu *QueueUpdate) ClearChatStart() *QueueUpdate {
 	return qu
 }
 
+// SetRenderChat sets the "render_chat" field.
+func (qu *QueueUpdate) SetRenderChat(b bool) *QueueUpdate {
+	qu.mutation.SetRenderChat(b)
+	return qu
+}
+
+// SetNillableRenderChat sets the "render_chat" field if the given value is not nil.
+func (qu *QueueUpdate) SetNillableRenderChat(b *bool) *QueueUpdate {
+	if b != nil {
+		qu.SetRenderChat(*b)
+	}
+	return qu
+}
+
+// ClearRenderChat clears the value of the "render_chat" field.
+func (qu *QueueUpdate) ClearRenderChat() *QueueUpdate {
+	qu.mutation.ClearRenderChat()
+	return qu
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (qu *QueueUpdate) SetUpdatedAt(t time.Time) *QueueUpdate {
 	qu.mutation.SetUpdatedAt(t)
@@ -544,6 +564,12 @@ func (qu *QueueUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if qu.mutation.ChatStartCleared() {
 		_spec.ClearField(queue.FieldChatStart, field.TypeTime)
+	}
+	if value, ok := qu.mutation.RenderChat(); ok {
+		_spec.SetField(queue.FieldRenderChat, field.TypeBool, value)
+	}
+	if qu.mutation.RenderChatCleared() {
+		_spec.ClearField(queue.FieldRenderChat, field.TypeBool)
 	}
 	if value, ok := qu.mutation.UpdatedAt(); ok {
 		_spec.SetField(queue.FieldUpdatedAt, field.TypeTime, value)
@@ -893,6 +919,26 @@ func (quo *QueueUpdateOne) ClearChatStart() *QueueUpdateOne {
 	return quo
 }
 
+// SetRenderChat sets the "render_chat" field.
+func (quo *QueueUpdateOne) SetRenderChat(b bool) *QueueUpdateOne {
+	quo.mutation.SetRenderChat(b)
+	return quo
+}
+
+// SetNillableRenderChat sets the "render_chat" field if the given value is not nil.
+func (quo *QueueUpdateOne) SetNillableRenderChat(b *bool) *QueueUpdateOne {
+	if b != nil {
+		quo.SetRenderChat(*b)
+	}
+	return quo
+}
+
+// ClearRenderChat clears the value of the "render_chat" field.
+func (quo *QueueUpdateOne) ClearRenderChat() *QueueUpdateOne {
+	quo.mutation.ClearRenderChat()
+	return quo
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (quo *QueueUpdateOne) SetUpdatedAt(t time.Time) *QueueUpdateOne {
 	quo.mutation.SetUpdatedAt(t)
@@ -1140,6 +1186,12 @@ func (quo *QueueUpdateOne) sqlSave(ctx context.Context) (_node *Queue, err error
 	}
 	if quo.mutation.ChatStartCleared() {
 		_spec.ClearField(queue.FieldChatStart, field.TypeTime)
+	}
+	if value, ok := quo.mutation.RenderChat(); ok {
+		_spec.SetField(queue.FieldRenderChat, field.TypeBool, value)
+	}
+	if quo.mutation.RenderChatCleared() {
+		_spec.ClearField(queue.FieldRenderChat, field.TypeBool)
 	}
 	if value, ok := quo.mutation.UpdatedAt(); ok {
 		_spec.SetField(queue.FieldUpdatedAt, field.TypeTime, value)

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -74,14 +74,18 @@ func init() {
 	liveDescLastLive := liveFields[9].Descriptor()
 	// live.DefaultLastLive holds the default value on creation for the last_live field.
 	live.DefaultLastLive = liveDescLastLive.Default.(func() time.Time)
+	// liveDescRenderChat is the schema descriptor for render_chat field.
+	liveDescRenderChat := liveFields[10].Descriptor()
+	// live.DefaultRenderChat holds the default value on creation for the render_chat field.
+	live.DefaultRenderChat = liveDescRenderChat.Default.(bool)
 	// liveDescUpdatedAt is the schema descriptor for updated_at field.
-	liveDescUpdatedAt := liveFields[10].Descriptor()
+	liveDescUpdatedAt := liveFields[11].Descriptor()
 	// live.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	live.DefaultUpdatedAt = liveDescUpdatedAt.Default.(func() time.Time)
 	// live.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	live.UpdateDefaultUpdatedAt = liveDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// liveDescCreatedAt is the schema descriptor for created_at field.
-	liveDescCreatedAt := liveFields[11].Descriptor()
+	liveDescCreatedAt := liveFields[12].Descriptor()
 	// live.DefaultCreatedAt holds the default value on creation for the created_at field.
 	live.DefaultCreatedAt = liveDescCreatedAt.Default.(func() time.Time)
 	// liveDescID is the schema descriptor for id field.
@@ -146,14 +150,18 @@ func init() {
 	queueDescProcessing := queueFields[5].Descriptor()
 	// queue.DefaultProcessing holds the default value on creation for the processing field.
 	queue.DefaultProcessing = queueDescProcessing.Default.(bool)
+	// queueDescRenderChat is the schema descriptor for render_chat field.
+	queueDescRenderChat := queueFields[17].Descriptor()
+	// queue.DefaultRenderChat holds the default value on creation for the render_chat field.
+	queue.DefaultRenderChat = queueDescRenderChat.Default.(bool)
 	// queueDescUpdatedAt is the schema descriptor for updated_at field.
-	queueDescUpdatedAt := queueFields[17].Descriptor()
+	queueDescUpdatedAt := queueFields[18].Descriptor()
 	// queue.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	queue.DefaultUpdatedAt = queueDescUpdatedAt.Default.(func() time.Time)
 	// queue.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	queue.UpdateDefaultUpdatedAt = queueDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// queueDescCreatedAt is the schema descriptor for created_at field.
-	queueDescCreatedAt := queueFields[18].Descriptor()
+	queueDescCreatedAt := queueFields[19].Descriptor()
 	// queue.DefaultCreatedAt holds the default value on creation for the created_at field.
 	queue.DefaultCreatedAt = queueDescCreatedAt.Default.(func() time.Time)
 	// queueDescID is the schema descriptor for id field.

--- a/ent/schema/live.go
+++ b/ent/schema/live.go
@@ -1,11 +1,12 @@
 package schema
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"github.com/google/uuid"
-	"time"
 )
 
 // Live holds the schema definition for the Live entity.
@@ -26,6 +27,7 @@ func (Live) Fields() []ent.Field {
 		field.Bool("archive_chat").Default(true).Comment("Whether the chat archive is enabled."),
 		field.String("resolution").Default("best").Optional(),
 		field.Time("last_live").Default(time.Now).Comment("The time the channel last went live."),
+		field.Bool("render_chat").Default(true).Comment("Whether the chat should be rendered."),
 		field.Time("updated_at").Default(time.Now).UpdateDefault(time.Now),
 		field.Time("created_at").Default(time.Now).Immutable(),
 	}

--- a/ent/schema/queue.go
+++ b/ent/schema/queue.go
@@ -1,12 +1,13 @@
 package schema
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"github.com/google/uuid"
 	"github.com/zibbp/ganymede/internal/utils"
-	"time"
 )
 
 // Queue holds the schema definition for the Queue entity.
@@ -34,6 +35,7 @@ func (Queue) Fields() []ent.Field {
 		field.Enum("task_chat_render").GoType(utils.TaskStatus("")).Default(string(utils.Pending)).Optional(),
 		field.Enum("task_chat_move").GoType(utils.TaskStatus("")).Default(string(utils.Pending)).Optional(),
 		field.Time("chat_start").Optional(),
+		field.Bool("render_chat").Optional().Default(true),
 		field.Time("updated_at").Default(time.Now).UpdateDefault(time.Now),
 		field.Time("created_at").Default(time.Now).Immutable(),
 	}

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -36,6 +36,7 @@ type Live struct {
 	ArchiveChat        bool      `json:"archive_chat"`
 	Resolution         string    `json:"resolution"`
 	LastLive           time.Time `json:"last_live"`
+	RenderChat         bool      `json:"render_chat"`
 }
 
 type ConvertChat struct {
@@ -68,7 +69,7 @@ func (s *Service) AddLiveWatchedChannel(c echo.Context, liveDto Live) (*ent.Live
 	if len(liveWatchedChannel) > 0 {
 		return nil, fmt.Errorf("channel already watched")
 	}
-	l, err := s.Store.Client.Live.Create().SetChannelID(liveDto.ID).SetWatchLive(liveDto.WatchLive).SetWatchVod(liveDto.WatchVod).SetDownloadArchives(liveDto.DownloadArchives).SetDownloadHighlights(liveDto.DownloadHighlights).SetDownloadUploads(liveDto.DownloadUploads).SetResolution(liveDto.Resolution).SetArchiveChat(liveDto.ArchiveChat).Save(c.Request().Context())
+	l, err := s.Store.Client.Live.Create().SetChannelID(liveDto.ID).SetWatchLive(liveDto.WatchLive).SetWatchVod(liveDto.WatchVod).SetDownloadArchives(liveDto.DownloadArchives).SetDownloadHighlights(liveDto.DownloadHighlights).SetDownloadUploads(liveDto.DownloadUploads).SetResolution(liveDto.Resolution).SetArchiveChat(liveDto.ArchiveChat).SetRenderChat(liveDto.RenderChat).Save(c.Request().Context())
 	if err != nil {
 		return nil, fmt.Errorf("error adding watched channel: %v", err)
 	}
@@ -76,7 +77,7 @@ func (s *Service) AddLiveWatchedChannel(c echo.Context, liveDto Live) (*ent.Live
 }
 
 func (s *Service) UpdateLiveWatchedChannel(c echo.Context, liveDto Live) (*ent.Live, error) {
-	l, err := s.Store.Client.Live.UpdateOneID(liveDto.ID).SetWatchLive(liveDto.WatchLive).SetWatchVod(liveDto.WatchVod).SetDownloadArchives(liveDto.DownloadArchives).SetDownloadHighlights(liveDto.DownloadHighlights).SetDownloadUploads(liveDto.DownloadUploads).SetResolution(liveDto.Resolution).SetArchiveChat(liveDto.ArchiveChat).Save(c.Request().Context())
+	l, err := s.Store.Client.Live.UpdateOneID(liveDto.ID).SetWatchLive(liveDto.WatchLive).SetWatchVod(liveDto.WatchVod).SetDownloadArchives(liveDto.DownloadArchives).SetDownloadHighlights(liveDto.DownloadHighlights).SetDownloadUploads(liveDto.DownloadUploads).SetResolution(liveDto.Resolution).SetArchiveChat(liveDto.ArchiveChat).SetRenderChat(liveDto.RenderChat).Save(c.Request().Context())
 	if err != nil {
 		return nil, fmt.Errorf("error updating watched channel: %v", err)
 	}

--- a/internal/live/vod.go
+++ b/internal/live/vod.go
@@ -2,6 +2,7 @@ package live
 
 import (
 	"context"
+
 	"github.com/rs/zerolog/log"
 	"github.com/zibbp/ganymede/ent"
 	"github.com/zibbp/ganymede/ent/channel"
@@ -101,7 +102,7 @@ func (s *Service) CheckVodWatchedChannels() {
 		for _, video := range videos {
 			if !contains(dbVideos, video.ID) {
 				// archive the video
-				_, err := s.ArchiveService.ArchiveTwitchVod(video.ID, watch.Resolution, watch.ArchiveChat)
+				_, err := s.ArchiveService.ArchiveTwitchVod(video.ID, watch.Resolution, watch.ArchiveChat, true)
 				if err != nil {
 					log.Error().Err(err).Msgf("Error archiving video %s", video.ID)
 					continue

--- a/internal/transport/http/archive.go
+++ b/internal/transport/http/archive.go
@@ -1,17 +1,18 @@
 package http
 
 import (
+	"net/http"
+
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/zibbp/ganymede/ent"
 	"github.com/zibbp/ganymede/internal/archive"
 	"github.com/zibbp/ganymede/internal/utils"
-	"net/http"
 )
 
 type ArchiveService interface {
 	ArchiveTwitchChannel(cName string) (*ent.Channel, error)
-	ArchiveTwitchVod(vID string, quality string, chat bool) (*archive.TwitchVodResponse, error)
+	ArchiveTwitchVod(vID string, quality string, chat bool, renderChat bool) (*archive.TwitchVodResponse, error)
 	RestartTask(c echo.Context, qID uuid.UUID, task string, cont bool) error
 }
 
@@ -19,9 +20,10 @@ type ArchiveChannelRequest struct {
 	ChannelName string `json:"channel_name" validate:"required"`
 }
 type ArchiveVodRequest struct {
-	VodID   string           `json:"vod_id" validate:"required"`
-	Quality utils.VodQuality `json:"quality" validate:"required,oneof=best source 720p60 480p30 360p30 160p30"`
-	Chat    bool             `json:"chat"`
+	VodID      string           `json:"vod_id" validate:"required"`
+	Quality    utils.VodQuality `json:"quality" validate:"required,oneof=best source 720p60 480p30 360p30 160p30"`
+	Chat       bool             `json:"chat"`
+	RenderChat bool             `json:"render_chat"`
 }
 
 type RestartTaskRequest struct {
@@ -53,7 +55,7 @@ func (h *Handler) ArchiveTwitchVod(c echo.Context) error {
 	if err := c.Validate(avr); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
-	vod, err := h.Service.ArchiveService.ArchiveTwitchVod(avr.VodID, string(avr.Quality), avr.Chat)
+	vod, err := h.Service.ArchiveService.ArchiveTwitchVod(avr.VodID, string(avr.Quality), avr.Chat, avr.RenderChat)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/internal/transport/http/live.go
+++ b/internal/transport/http/live.go
@@ -1,11 +1,12 @@
 package http
 
 import (
+	"net/http"
+
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/zibbp/ganymede/ent"
 	"github.com/zibbp/ganymede/internal/live"
-	"net/http"
 )
 
 type LiveService interface {
@@ -27,6 +28,7 @@ type AddWatchedChannelRequest struct {
 	ChannelID          string `json:"channel_id" validate:"required"`
 	Resolution         string `json:"resolution" validate:"required,oneof=best source 720p60 480p30 360p30 160p30"`
 	ArchiveChat        bool   `json:"archive_chat"`
+	RenderChat         bool   `json:"render_chat"`
 }
 
 type UpdateWatchedChannelRequest struct {
@@ -37,6 +39,7 @@ type UpdateWatchedChannelRequest struct {
 	DownloadUploads    bool   `json:"download_uploads"`
 	Resolution         string `json:"resolution" validate:"required,oneof=best source 720p60 480p30 360p30 160p30"`
 	ArchiveChat        bool   `json:"archive_chat"`
+	RenderChat         bool   `json:"render_chat"`
 }
 
 type ConvertChatRequest struct {
@@ -79,6 +82,7 @@ func (h *Handler) AddLiveWatchedChannel(c echo.Context) error {
 		IsLive:             false,
 		ArchiveChat:        ccr.ArchiveChat,
 		Resolution:         ccr.Resolution,
+		RenderChat:         ccr.RenderChat,
 	}
 	l, err := h.Service.LiveService.AddLiveWatchedChannel(c, liveDto)
 	if err != nil {
@@ -110,6 +114,7 @@ func (h *Handler) UpdateLiveWatchedChannel(c echo.Context) error {
 		DownloadUploads:    ccr.DownloadUploads,
 		ArchiveChat:        ccr.ArchiveChat,
 		Resolution:         ccr.Resolution,
+		RenderChat:         ccr.RenderChat,
 	}
 	l, err := h.Service.LiveService.UpdateLiveWatchedChannel(c, liveDto)
 	if err != nil {


### PR DESCRIPTION
This PR adds support for a "render chat" option. Some users may not want to chat rendered and this gives them the ability to disable that. The option is a slider next to the "archive chat" slider on the archive page and the watched channels page.
