### PR TITLE
Watched channels subscriber only videos

### DIFF
--- a/ent/live.go
+++ b/ent/live.go
@@ -28,6 +28,8 @@ type Live struct {
 	DownloadHighlights bool `json:"download_highlights,omitempty"`
 	// Download uploads
 	DownloadUploads bool `json:"download_uploads,omitempty"`
+	// Download sub only VODs
+	DownloadSubOnly bool `json:"download_sub_only,omitempty"`
 	// Whether the channel is currently live.
 	IsLive bool `json:"is_live,omitempty"`
 	// Whether the chat archive is enabled.
@@ -75,7 +77,7 @@ func (*Live) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case live.FieldWatchLive, live.FieldWatchVod, live.FieldDownloadArchives, live.FieldDownloadHighlights, live.FieldDownloadUploads, live.FieldIsLive, live.FieldArchiveChat, live.FieldRenderChat:
+		case live.FieldWatchLive, live.FieldWatchVod, live.FieldDownloadArchives, live.FieldDownloadHighlights, live.FieldDownloadUploads, live.FieldDownloadSubOnly, live.FieldIsLive, live.FieldArchiveChat, live.FieldRenderChat:
 			values[i] = new(sql.NullBool)
 		case live.FieldResolution:
 			values[i] = new(sql.NullString)
@@ -135,6 +137,12 @@ func (l *Live) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field download_uploads", values[i])
 			} else if value.Valid {
 				l.DownloadUploads = value.Bool
+			}
+		case live.FieldDownloadSubOnly:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field download_sub_only", values[i])
+			} else if value.Valid {
+				l.DownloadSubOnly = value.Bool
 			}
 		case live.FieldIsLive:
 			if value, ok := values[i].(*sql.NullBool); !ok {
@@ -232,6 +240,9 @@ func (l *Live) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("download_uploads=")
 	builder.WriteString(fmt.Sprintf("%v", l.DownloadUploads))
+	builder.WriteString(", ")
+	builder.WriteString("download_sub_only=")
+	builder.WriteString(fmt.Sprintf("%v", l.DownloadSubOnly))
 	builder.WriteString(", ")
 	builder.WriteString("is_live=")
 	builder.WriteString(fmt.Sprintf("%v", l.IsLive))

--- a/ent/live/live.go
+++ b/ent/live/live.go
@@ -23,6 +23,8 @@ const (
 	FieldDownloadHighlights = "download_highlights"
 	// FieldDownloadUploads holds the string denoting the download_uploads field in the database.
 	FieldDownloadUploads = "download_uploads"
+	// FieldDownloadSubOnly holds the string denoting the download_sub_only field in the database.
+	FieldDownloadSubOnly = "download_sub_only"
 	// FieldIsLive holds the string denoting the is_live field in the database.
 	FieldIsLive = "is_live"
 	// FieldArchiveChat holds the string denoting the archive_chat field in the database.
@@ -58,6 +60,7 @@ var Columns = []string{
 	FieldDownloadArchives,
 	FieldDownloadHighlights,
 	FieldDownloadUploads,
+	FieldDownloadSubOnly,
 	FieldIsLive,
 	FieldArchiveChat,
 	FieldResolution,
@@ -99,6 +102,8 @@ var (
 	DefaultDownloadHighlights bool
 	// DefaultDownloadUploads holds the default value on creation for the "download_uploads" field.
 	DefaultDownloadUploads bool
+	// DefaultDownloadSubOnly holds the default value on creation for the "download_sub_only" field.
+	DefaultDownloadSubOnly bool
 	// DefaultIsLive holds the default value on creation for the "is_live" field.
 	DefaultIsLive bool
 	// DefaultArchiveChat holds the default value on creation for the "archive_chat" field.

--- a/ent/live/where.go
+++ b/ent/live/where.go
@@ -81,6 +81,11 @@ func DownloadUploads(v bool) predicate.Live {
 	return predicate.Live(sql.FieldEQ(FieldDownloadUploads, v))
 }
 
+// DownloadSubOnly applies equality check predicate on the "download_sub_only" field. It's identical to DownloadSubOnlyEQ.
+func DownloadSubOnly(v bool) predicate.Live {
+	return predicate.Live(sql.FieldEQ(FieldDownloadSubOnly, v))
+}
+
 // IsLive applies equality check predicate on the "is_live" field. It's identical to IsLiveEQ.
 func IsLive(v bool) predicate.Live {
 	return predicate.Live(sql.FieldEQ(FieldIsLive, v))
@@ -164,6 +169,16 @@ func DownloadUploadsEQ(v bool) predicate.Live {
 // DownloadUploadsNEQ applies the NEQ predicate on the "download_uploads" field.
 func DownloadUploadsNEQ(v bool) predicate.Live {
 	return predicate.Live(sql.FieldNEQ(FieldDownloadUploads, v))
+}
+
+// DownloadSubOnlyEQ applies the EQ predicate on the "download_sub_only" field.
+func DownloadSubOnlyEQ(v bool) predicate.Live {
+	return predicate.Live(sql.FieldEQ(FieldDownloadSubOnly, v))
+}
+
+// DownloadSubOnlyNEQ applies the NEQ predicate on the "download_sub_only" field.
+func DownloadSubOnlyNEQ(v bool) predicate.Live {
+	return predicate.Live(sql.FieldNEQ(FieldDownloadSubOnly, v))
 }
 
 // IsLiveEQ applies the EQ predicate on the "is_live" field.

--- a/ent/live_create.go
+++ b/ent/live_create.go
@@ -92,6 +92,20 @@ func (lc *LiveCreate) SetNillableDownloadUploads(b *bool) *LiveCreate {
 	return lc
 }
 
+// SetDownloadSubOnly sets the "download_sub_only" field.
+func (lc *LiveCreate) SetDownloadSubOnly(b bool) *LiveCreate {
+	lc.mutation.SetDownloadSubOnly(b)
+	return lc
+}
+
+// SetNillableDownloadSubOnly sets the "download_sub_only" field if the given value is not nil.
+func (lc *LiveCreate) SetNillableDownloadSubOnly(b *bool) *LiveCreate {
+	if b != nil {
+		lc.SetDownloadSubOnly(*b)
+	}
+	return lc
+}
+
 // SetIsLive sets the "is_live" field.
 func (lc *LiveCreate) SetIsLive(b bool) *LiveCreate {
 	lc.mutation.SetIsLive(b)
@@ -270,6 +284,10 @@ func (lc *LiveCreate) defaults() {
 		v := live.DefaultDownloadUploads
 		lc.mutation.SetDownloadUploads(v)
 	}
+	if _, ok := lc.mutation.DownloadSubOnly(); !ok {
+		v := live.DefaultDownloadSubOnly
+		lc.mutation.SetDownloadSubOnly(v)
+	}
 	if _, ok := lc.mutation.IsLive(); !ok {
 		v := live.DefaultIsLive
 		lc.mutation.SetIsLive(v)
@@ -320,6 +338,9 @@ func (lc *LiveCreate) check() error {
 	}
 	if _, ok := lc.mutation.DownloadUploads(); !ok {
 		return &ValidationError{Name: "download_uploads", err: errors.New(`ent: missing required field "Live.download_uploads"`)}
+	}
+	if _, ok := lc.mutation.DownloadSubOnly(); !ok {
+		return &ValidationError{Name: "download_sub_only", err: errors.New(`ent: missing required field "Live.download_sub_only"`)}
 	}
 	if _, ok := lc.mutation.IsLive(); !ok {
 		return &ValidationError{Name: "is_live", err: errors.New(`ent: missing required field "Live.is_live"`)}
@@ -402,6 +423,10 @@ func (lc *LiveCreate) createSpec() (*Live, *sqlgraph.CreateSpec) {
 	if value, ok := lc.mutation.DownloadUploads(); ok {
 		_spec.SetField(live.FieldDownloadUploads, field.TypeBool, value)
 		_node.DownloadUploads = value
+	}
+	if value, ok := lc.mutation.DownloadSubOnly(); ok {
+		_spec.SetField(live.FieldDownloadSubOnly, field.TypeBool, value)
+		_node.DownloadSubOnly = value
 	}
 	if value, ok := lc.mutation.IsLive(); ok {
 		_spec.SetField(live.FieldIsLive, field.TypeBool, value)

--- a/ent/live_update.go
+++ b/ent/live_update.go
@@ -100,6 +100,20 @@ func (lu *LiveUpdate) SetNillableDownloadUploads(b *bool) *LiveUpdate {
 	return lu
 }
 
+// SetDownloadSubOnly sets the "download_sub_only" field.
+func (lu *LiveUpdate) SetDownloadSubOnly(b bool) *LiveUpdate {
+	lu.mutation.SetDownloadSubOnly(b)
+	return lu
+}
+
+// SetNillableDownloadSubOnly sets the "download_sub_only" field if the given value is not nil.
+func (lu *LiveUpdate) SetNillableDownloadSubOnly(b *bool) *LiveUpdate {
+	if b != nil {
+		lu.SetDownloadSubOnly(*b)
+	}
+	return lu
+}
+
 // SetIsLive sets the "is_live" field.
 func (lu *LiveUpdate) SetIsLive(b bool) *LiveUpdate {
 	lu.mutation.SetIsLive(b)
@@ -284,6 +298,9 @@ func (lu *LiveUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if value, ok := lu.mutation.DownloadUploads(); ok {
 		_spec.SetField(live.FieldDownloadUploads, field.TypeBool, value)
 	}
+	if value, ok := lu.mutation.DownloadSubOnly(); ok {
+		_spec.SetField(live.FieldDownloadSubOnly, field.TypeBool, value)
+	}
 	if value, ok := lu.mutation.IsLive(); ok {
 		_spec.SetField(live.FieldIsLive, field.TypeBool, value)
 	}
@@ -426,6 +443,20 @@ func (luo *LiveUpdateOne) SetDownloadUploads(b bool) *LiveUpdateOne {
 func (luo *LiveUpdateOne) SetNillableDownloadUploads(b *bool) *LiveUpdateOne {
 	if b != nil {
 		luo.SetDownloadUploads(*b)
+	}
+	return luo
+}
+
+// SetDownloadSubOnly sets the "download_sub_only" field.
+func (luo *LiveUpdateOne) SetDownloadSubOnly(b bool) *LiveUpdateOne {
+	luo.mutation.SetDownloadSubOnly(b)
+	return luo
+}
+
+// SetNillableDownloadSubOnly sets the "download_sub_only" field if the given value is not nil.
+func (luo *LiveUpdateOne) SetNillableDownloadSubOnly(b *bool) *LiveUpdateOne {
+	if b != nil {
+		luo.SetDownloadSubOnly(*b)
 	}
 	return luo
 }
@@ -637,6 +668,9 @@ func (luo *LiveUpdateOne) sqlSave(ctx context.Context) (_node *Live, err error) 
 	}
 	if value, ok := luo.mutation.DownloadUploads(); ok {
 		_spec.SetField(live.FieldDownloadUploads, field.TypeBool, value)
+	}
+	if value, ok := luo.mutation.DownloadSubOnly(); ok {
+		_spec.SetField(live.FieldDownloadSubOnly, field.TypeBool, value)
 	}
 	if value, ok := luo.mutation.IsLive(); ok {
 		_spec.SetField(live.FieldIsLive, field.TypeBool, value)

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -32,6 +32,7 @@ var (
 		{Name: "download_archives", Type: field.TypeBool, Default: false},
 		{Name: "download_highlights", Type: field.TypeBool, Default: false},
 		{Name: "download_uploads", Type: field.TypeBool, Default: false},
+		{Name: "download_sub_only", Type: field.TypeBool, Default: false},
 		{Name: "is_live", Type: field.TypeBool, Default: false},
 		{Name: "archive_chat", Type: field.TypeBool, Default: true},
 		{Name: "resolution", Type: field.TypeString, Nullable: true, Default: "best"},
@@ -49,7 +50,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "lives_channels_live",
-				Columns:    []*schema.Column{LivesColumns[13]},
+				Columns:    []*schema.Column{LivesColumns[14]},
 				RefColumns: []*schema.Column{ChannelsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -853,6 +853,7 @@ type LiveMutation struct {
 	download_archives   *bool
 	download_highlights *bool
 	download_uploads    *bool
+	download_sub_only   *bool
 	is_live             *bool
 	archive_chat        *bool
 	resolution          *string
@@ -1150,6 +1151,42 @@ func (m *LiveMutation) OldDownloadUploads(ctx context.Context) (v bool, err erro
 // ResetDownloadUploads resets all changes to the "download_uploads" field.
 func (m *LiveMutation) ResetDownloadUploads() {
 	m.download_uploads = nil
+}
+
+// SetDownloadSubOnly sets the "download_sub_only" field.
+func (m *LiveMutation) SetDownloadSubOnly(b bool) {
+	m.download_sub_only = &b
+}
+
+// DownloadSubOnly returns the value of the "download_sub_only" field in the mutation.
+func (m *LiveMutation) DownloadSubOnly() (r bool, exists bool) {
+	v := m.download_sub_only
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDownloadSubOnly returns the old "download_sub_only" field's value of the Live entity.
+// If the Live object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *LiveMutation) OldDownloadSubOnly(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDownloadSubOnly is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDownloadSubOnly requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDownloadSubOnly: %w", err)
+	}
+	return oldValue.DownloadSubOnly, nil
+}
+
+// ResetDownloadSubOnly resets all changes to the "download_sub_only" field.
+func (m *LiveMutation) ResetDownloadSubOnly() {
+	m.download_sub_only = nil
 }
 
 // SetIsLive sets the "is_live" field.
@@ -1490,7 +1527,7 @@ func (m *LiveMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *LiveMutation) Fields() []string {
-	fields := make([]string, 0, 12)
+	fields := make([]string, 0, 13)
 	if m.watch_live != nil {
 		fields = append(fields, live.FieldWatchLive)
 	}
@@ -1505,6 +1542,9 @@ func (m *LiveMutation) Fields() []string {
 	}
 	if m.download_uploads != nil {
 		fields = append(fields, live.FieldDownloadUploads)
+	}
+	if m.download_sub_only != nil {
+		fields = append(fields, live.FieldDownloadSubOnly)
 	}
 	if m.is_live != nil {
 		fields = append(fields, live.FieldIsLive)
@@ -1545,6 +1585,8 @@ func (m *LiveMutation) Field(name string) (ent.Value, bool) {
 		return m.DownloadHighlights()
 	case live.FieldDownloadUploads:
 		return m.DownloadUploads()
+	case live.FieldDownloadSubOnly:
+		return m.DownloadSubOnly()
 	case live.FieldIsLive:
 		return m.IsLive()
 	case live.FieldArchiveChat:
@@ -1578,6 +1620,8 @@ func (m *LiveMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldDownloadHighlights(ctx)
 	case live.FieldDownloadUploads:
 		return m.OldDownloadUploads(ctx)
+	case live.FieldDownloadSubOnly:
+		return m.OldDownloadSubOnly(ctx)
 	case live.FieldIsLive:
 		return m.OldIsLive(ctx)
 	case live.FieldArchiveChat:
@@ -1635,6 +1679,13 @@ func (m *LiveMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetDownloadUploads(v)
+		return nil
+	case live.FieldDownloadSubOnly:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDownloadSubOnly(v)
 		return nil
 	case live.FieldIsLive:
 		v, ok := value.(bool)
@@ -1757,6 +1808,9 @@ func (m *LiveMutation) ResetField(name string) error {
 		return nil
 	case live.FieldDownloadUploads:
 		m.ResetDownloadUploads()
+		return nil
+	case live.FieldDownloadSubOnly:
+		m.ResetDownloadSubOnly()
 		return nil
 	case live.FieldIsLive:
 		m.ResetIsLive()

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -58,34 +58,38 @@ func init() {
 	liveDescDownloadUploads := liveFields[5].Descriptor()
 	// live.DefaultDownloadUploads holds the default value on creation for the download_uploads field.
 	live.DefaultDownloadUploads = liveDescDownloadUploads.Default.(bool)
+	// liveDescDownloadSubOnly is the schema descriptor for download_sub_only field.
+	liveDescDownloadSubOnly := liveFields[6].Descriptor()
+	// live.DefaultDownloadSubOnly holds the default value on creation for the download_sub_only field.
+	live.DefaultDownloadSubOnly = liveDescDownloadSubOnly.Default.(bool)
 	// liveDescIsLive is the schema descriptor for is_live field.
-	liveDescIsLive := liveFields[6].Descriptor()
+	liveDescIsLive := liveFields[7].Descriptor()
 	// live.DefaultIsLive holds the default value on creation for the is_live field.
 	live.DefaultIsLive = liveDescIsLive.Default.(bool)
 	// liveDescArchiveChat is the schema descriptor for archive_chat field.
-	liveDescArchiveChat := liveFields[7].Descriptor()
+	liveDescArchiveChat := liveFields[8].Descriptor()
 	// live.DefaultArchiveChat holds the default value on creation for the archive_chat field.
 	live.DefaultArchiveChat = liveDescArchiveChat.Default.(bool)
 	// liveDescResolution is the schema descriptor for resolution field.
-	liveDescResolution := liveFields[8].Descriptor()
+	liveDescResolution := liveFields[9].Descriptor()
 	// live.DefaultResolution holds the default value on creation for the resolution field.
 	live.DefaultResolution = liveDescResolution.Default.(string)
 	// liveDescLastLive is the schema descriptor for last_live field.
-	liveDescLastLive := liveFields[9].Descriptor()
+	liveDescLastLive := liveFields[10].Descriptor()
 	// live.DefaultLastLive holds the default value on creation for the last_live field.
 	live.DefaultLastLive = liveDescLastLive.Default.(func() time.Time)
 	// liveDescRenderChat is the schema descriptor for render_chat field.
-	liveDescRenderChat := liveFields[10].Descriptor()
+	liveDescRenderChat := liveFields[11].Descriptor()
 	// live.DefaultRenderChat holds the default value on creation for the render_chat field.
 	live.DefaultRenderChat = liveDescRenderChat.Default.(bool)
 	// liveDescUpdatedAt is the schema descriptor for updated_at field.
-	liveDescUpdatedAt := liveFields[11].Descriptor()
+	liveDescUpdatedAt := liveFields[12].Descriptor()
 	// live.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	live.DefaultUpdatedAt = liveDescUpdatedAt.Default.(func() time.Time)
 	// live.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	live.UpdateDefaultUpdatedAt = liveDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// liveDescCreatedAt is the schema descriptor for created_at field.
-	liveDescCreatedAt := liveFields[12].Descriptor()
+	liveDescCreatedAt := liveFields[13].Descriptor()
 	// live.DefaultCreatedAt holds the default value on creation for the created_at field.
 	live.DefaultCreatedAt = liveDescCreatedAt.Default.(func() time.Time)
 	// liveDescID is the schema descriptor for id field.

--- a/ent/schema/live.go
+++ b/ent/schema/live.go
@@ -23,6 +23,7 @@ func (Live) Fields() []ent.Field {
 		field.Bool("download_archives").Default(false).Comment("Download archives"),
 		field.Bool("download_highlights").Default(false).Comment("Download highlights"),
 		field.Bool("download_uploads").Default(false).Comment("Download uploads"),
+		field.Bool("download_sub_only").Default(false).Comment("Download sub only VODs"),
 		field.Bool("is_live").Default(false).Comment("Whether the channel is currently live."),
 		field.Bool("archive_chat").Default(true).Comment("Whether the chat archive is enabled."),
 		field.String("resolution").Default("best").Optional(),

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -37,6 +37,7 @@ type Live struct {
 	Resolution         string    `json:"resolution"`
 	LastLive           time.Time `json:"last_live"`
 	RenderChat         bool      `json:"render_chat"`
+	DownloadSubOnly    bool      `json:"download_sub_only"`
 }
 
 type ConvertChat struct {
@@ -69,7 +70,7 @@ func (s *Service) AddLiveWatchedChannel(c echo.Context, liveDto Live) (*ent.Live
 	if len(liveWatchedChannel) > 0 {
 		return nil, fmt.Errorf("channel already watched")
 	}
-	l, err := s.Store.Client.Live.Create().SetChannelID(liveDto.ID).SetWatchLive(liveDto.WatchLive).SetWatchVod(liveDto.WatchVod).SetDownloadArchives(liveDto.DownloadArchives).SetDownloadHighlights(liveDto.DownloadHighlights).SetDownloadUploads(liveDto.DownloadUploads).SetResolution(liveDto.Resolution).SetArchiveChat(liveDto.ArchiveChat).SetRenderChat(liveDto.RenderChat).Save(c.Request().Context())
+	l, err := s.Store.Client.Live.Create().SetChannelID(liveDto.ID).SetWatchLive(liveDto.WatchLive).SetWatchVod(liveDto.WatchVod).SetDownloadArchives(liveDto.DownloadArchives).SetDownloadHighlights(liveDto.DownloadHighlights).SetDownloadUploads(liveDto.DownloadUploads).SetResolution(liveDto.Resolution).SetArchiveChat(liveDto.ArchiveChat).SetRenderChat(liveDto.RenderChat).SetDownloadSubOnly(liveDto.DownloadSubOnly).Save(c.Request().Context())
 	if err != nil {
 		return nil, fmt.Errorf("error adding watched channel: %v", err)
 	}
@@ -77,7 +78,7 @@ func (s *Service) AddLiveWatchedChannel(c echo.Context, liveDto Live) (*ent.Live
 }
 
 func (s *Service) UpdateLiveWatchedChannel(c echo.Context, liveDto Live) (*ent.Live, error) {
-	l, err := s.Store.Client.Live.UpdateOneID(liveDto.ID).SetWatchLive(liveDto.WatchLive).SetWatchVod(liveDto.WatchVod).SetDownloadArchives(liveDto.DownloadArchives).SetDownloadHighlights(liveDto.DownloadHighlights).SetDownloadUploads(liveDto.DownloadUploads).SetResolution(liveDto.Resolution).SetArchiveChat(liveDto.ArchiveChat).SetRenderChat(liveDto.RenderChat).Save(c.Request().Context())
+	l, err := s.Store.Client.Live.UpdateOneID(liveDto.ID).SetWatchLive(liveDto.WatchLive).SetWatchVod(liveDto.WatchVod).SetDownloadArchives(liveDto.DownloadArchives).SetDownloadHighlights(liveDto.DownloadHighlights).SetDownloadUploads(liveDto.DownloadUploads).SetResolution(liveDto.Resolution).SetArchiveChat(liveDto.ArchiveChat).SetRenderChat(liveDto.RenderChat).SetDownloadSubOnly(liveDto.DownloadSubOnly).Save(c.Request().Context())
 	if err != nil {
 		return nil, fmt.Errorf("error updating watched channel: %v", err)
 	}

--- a/internal/transport/http/handler.go
+++ b/internal/transport/http/handler.go
@@ -184,6 +184,7 @@ func groupV1Routes(e *echo.Group, h *Handler) {
 	twitchGroup := e.Group("/twitch")
 	twitchGroup.GET("/channel", h.GetTwitchUser)
 	twitchGroup.GET("/vod", h.GetTwitchVod)
+	twitchGroup.GET("/gql/video", h.GQLGetTwitchVideo)
 
 	// Archive
 	archiveGroup := e.Group("/archive")

--- a/internal/transport/http/live.go
+++ b/internal/transport/http/live.go
@@ -29,6 +29,7 @@ type AddWatchedChannelRequest struct {
 	Resolution         string `json:"resolution" validate:"required,oneof=best source 720p60 480p30 360p30 160p30"`
 	ArchiveChat        bool   `json:"archive_chat"`
 	RenderChat         bool   `json:"render_chat"`
+	DownloadSubOnly    bool   `json:"download_sub_only"`
 }
 
 type UpdateWatchedChannelRequest struct {
@@ -40,6 +41,7 @@ type UpdateWatchedChannelRequest struct {
 	Resolution         string `json:"resolution" validate:"required,oneof=best source 720p60 480p30 360p30 160p30"`
 	ArchiveChat        bool   `json:"archive_chat"`
 	RenderChat         bool   `json:"render_chat"`
+	DownloadSubOnly    bool   `json:"download_sub_only"`
 }
 
 type ConvertChatRequest struct {
@@ -83,6 +85,7 @@ func (h *Handler) AddLiveWatchedChannel(c echo.Context) error {
 		ArchiveChat:        ccr.ArchiveChat,
 		Resolution:         ccr.Resolution,
 		RenderChat:         ccr.RenderChat,
+		DownloadSubOnly:    ccr.DownloadSubOnly,
 	}
 	l, err := h.Service.LiveService.AddLiveWatchedChannel(c, liveDto)
 	if err != nil {
@@ -115,6 +118,7 @@ func (h *Handler) UpdateLiveWatchedChannel(c echo.Context) error {
 		ArchiveChat:        ccr.ArchiveChat,
 		Resolution:         ccr.Resolution,
 		RenderChat:         ccr.RenderChat,
+		DownloadSubOnly:    ccr.DownloadSubOnly,
 	}
 	l, err := h.Service.LiveService.UpdateLiveWatchedChannel(c, liveDto)
 	if err != nil {

--- a/internal/transport/http/twitch.go
+++ b/internal/transport/http/twitch.go
@@ -1,9 +1,10 @@
 package http
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	"github.com/zibbp/ganymede/internal/twitch"
-	"net/http"
 )
 
 type TwitchService interface {
@@ -35,4 +36,17 @@ func (h *Handler) GetTwitchVod(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, vod)
+}
+
+func (h *Handler) GQLGetTwitchVideo(c echo.Context) error {
+	videoID := c.QueryParam("id")
+	if videoID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "id query param is required")
+	}
+	video, err := twitch.GQLGetVideo(videoID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, video)
 }

--- a/internal/twitch/gql.go
+++ b/internal/twitch/gql.go
@@ -1,0 +1,81 @@
+package twitch
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type GQLResponse struct {
+	Data       Data       `json:"data"`
+	Extensions Extensions `json:"extensions"`
+}
+
+type Data struct {
+	Video GQLVideo `json:"video"`
+}
+
+type GQLVideo struct {
+	BroadcastType       string              `json:"broadcastType"`
+	ResourceRestriction ResourceRestriction `json:"resourceRestriction"`
+	Title               string              `json:"title"`
+	CreatedAt           string              `json:"createdAt"`
+}
+
+type ResourceRestriction struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+type Extensions struct {
+	DurationMilliseconds int64  `json:"durationMilliseconds"`
+	RequestID            string `json:"requestID"`
+}
+
+func gqlRequest(body string) (GQLResponse, error) {
+	var response GQLResponse
+
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", "https://gql.twitch.tv/gql", strings.NewReader(body))
+	if err != nil {
+		return response, err
+	}
+	req.Header.Set("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko")
+	req.Header.Set("Content-Type", "text/plain;charset=UTF-8")
+	req.Header.Set("Origin", "https://www.twitch.tv")
+	req.Header.Set("Referer", "https://www.twitch.tv/")
+	req.Header.Set("Sec-Fetch-Mode", "cors")
+	req.Header.Set("Sec-Fetch-Site", "same-site")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return response, fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return response, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return response, fmt.Errorf("error unmarshalling response: %w", err)
+	}
+
+	return response, nil
+
+}
+
+func GQLGetVideo(id string) (GQLResponse, error) {
+	body := fmt.Sprintf(`{"query": "query{video(id:%s){broadcastType,resourceRestriction{id,type},title,createdAt}}"}`, id)
+	resp, err := gqlRequest(body)
+	if err != nil {
+		return resp, fmt.Errorf("error getting video: %w", err)
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
Adds the ability to enable or disable downloading subscriber-only videos when watching a channel for new videos. 
![image](https://user-images.githubusercontent.com/21207065/213735893-bbea75ac-ce5d-43f3-a8c0-df8e3738da6c.png)

Twitch's Helix API does not expose the information whether a video has a sub-only restriction or not. I am using Twitch's undocumented GraphQL API to perform the check. The check occurs near the end of the "CheckVodWatchedChannels" function when it has been determined the video ID is new and not already archived. The graphql request is made and the response is checked to determine if a sub-only restriction is enabled. If so, and the "download sub only" option is disabled, the video is skipped. If not, the Twitch token is checked to ensure it is set then the video is sent to the queue.