### PR TITLE
Create Dockerfile.aarch64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -74,8 +74,6 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
           platforms: linux/amd64
           file: Dockerfile
-          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}
-          cache-to: type=gha,scope=${{ env.IMAGE_NAME }},mode=max
 
   build-push-arm64:
     # Only run on release tags
@@ -133,5 +131,3 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
           platforms: linux/arm64
           file: Dockerfile.aarch64
-          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}-arm64
-          cache-to: type=gha,scope=${{ env.IMAGE_NAME }}-arm64,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  build-docker-amd64:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -74,6 +74,46 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
           platforms: linux/amd64
           file: Dockerfile
+
+  build-docker-arm64:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image for arm64
         id: build-and-push-arm64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -130,6 +130,6 @@ jobs:
           secrets: |
             VERSION=${{ steps.meta.outputs.version }}
           platforms: linux/arm64
-          file: Dockerfile
+          file: Dockerfile.aarch64
           cache-from: type=gha,scope=${{ env.IMAGE_NAME }}-arm64
           cache-to: type=gha,scope=${{ env.IMAGE_NAME }}-arm64,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,22 +31,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v2.1.0
         with:
           platforms: all
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@v2.2.1
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v2.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -56,7 +56,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4.3.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -64,7 +64,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image for amd64
         id: build-and-push-amd64
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@v3.3.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -86,22 +86,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v2.1.0
         with:
           platforms: all
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@v2.2.1
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v2.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -111,13 +111,13 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4.3.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image for arm64
         id: build-and-push-arm64
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@v3.3.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -78,6 +78,8 @@ jobs:
           cache-to: type=gha,scope=${{ env.IMAGE_NAME }},mode=max
 
   build-push-arm64:
+    # Only run on release tags
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,11 +7,11 @@ name: Docker
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: ["v*.*.*"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -19,10 +19,8 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,14 +33,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-#       # Install the cosign tool except on PR
-#       # https://github.com/sigstore/cosign-installer
-#       - name: Install cosign
-#         if: github.event_name != 'pull_request'
-#         uses: sigstore/cosign-installer@7e0881f8fe90b25e305bbf0309761e9314607e25
-#         with:
-#           cosign-release: 'v1.9.0'
-
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
@@ -68,8 +62,8 @@ jobs:
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        id: build-and-push
+      - name: Build and push Docker image for amd64
+        id: build-and-push-amd64
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
@@ -78,16 +72,18 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
             VERSION=${{ steps.meta.outputs.version }}
+          platforms: linux/amd64
+          file: Dockerfile
 
-#       # Sign the resulting Docker image digest except on PRs.
-#       # This will only write to the public Rekor transparency log when the Docker
-#       # repository is public to avoid leaking data.  If you would like to publish
-#       # transparency data even for private images, pass --force to cosign below.
-#       # https://github.com/sigstore/cosign
-#       - name: Sign the published Docker image
-#         if: ${{ github.event_name != 'pull_request' }}
-#         env:
-#           COSIGN_EXPERIMENTAL: "true"
-#         # This step uses the identity token to provision an ephemeral certificate
-#         # against the sigstore community Fulcio instance.
-#         run: cosign sign ${{ steps.meta.outputs.tags }}@${{ steps.build-and-push.outputs.digest }}
+      - name: Build and push Docker image for arm64
+        id: build-and-push-arm64
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            VERSION=${{ steps.meta.outputs.version }}
+          platforms: linux/arm64
+          file: Dockerfile.aarch64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-docker-amd64:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -72,58 +72,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
             VERSION=${{ steps.meta.outputs.version }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           file: Dockerfile
-
-  build-docker-arm64:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3.3.0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.1.0
-        with:
-          platforms: all
-
-      # Workaround: https://github.com/docker/build-push-action/issues/461
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2.2.1
-
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2.1.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v4.3.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image for arm64
-        id: build-and-push-arm64
-        uses: docker/build-push-action@v3.3.0
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          secrets: |
-            VERSION=${{ steps.meta.outputs.version }}
-          platforms: linux/arm64
-          file: Dockerfile.aarch64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  build-push-amd64:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -62,7 +62,7 @@ jobs:
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image for amd64
+      - name: Build and push Docker image (amd64)
         id: build-and-push-amd64
         uses: docker/build-push-action@v3.3.0
         with:
@@ -72,5 +72,64 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
             VERSION=${{ steps.meta.outputs.version }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           file: Dockerfile
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}
+          cache-to: type=gha,scope=${{ env.IMAGE_NAME }},mode=max
+
+  build-push-arm64:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.3.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        with:
+          platforms: all
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2.2.1
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image (arm64)
+        id: build-and-push-arm64
+        uses: docker/build-push-action@v3.3.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}-arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            VERSION=${{ steps.meta.outputs.version }}
+          platforms: linux/arm64
+          file: Dockerfile
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}-arm64
+          cache-to: type=gha,scope=${{ env.IMAGE_NAME }}-arm64,mode=max

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,52 @@
+FROM arm64v8/golang:1.18 AS build-stage-01
+
+RUN mkdir /app
+ADD . /app
+WORKDIR /app
+
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -X main.Version=${VERSION} -X main.BuildTime=`TZ=UTC date -u '+%Y-%m-%dT%H:%M:%SZ'` -X main.GitHash=`git rev-parse HEAD`" -o ganymede-api cmd/server/main.go
+
+FROM arm64v8/debian AS build-stage-02
+
+RUN apt-get update
+RUN apt-get install unzip wget git -y
+
+WORKDIR /tmp
+RUN wget https://github.com/rsms/inter/releases/download/v3.19/Inter-3.19.zip && unzip Inter-3.19.zip
+RUN wget https://github.com/lay295/TwitchDownloader/releases/download/1.51.1/TwitchDownloaderCLI-1.51.1-LinuxArm.zip && unzip TwitchDownloaderCLI-1.51.1-LinuxArm.zip
+
+RUN git clone https://github.com/xenova/chat-downloader.git
+
+FROM arm64v8/debian AS production
+
+## Add armhf support.
+RUN dpkg --add-architecture armhf
+
+RUN apt-get update
+RUN apt-get install python3 python3-pip fontconfig icu-devtools python3-dev gcc g++ ffmpeg bash tzdata -y
+RUN pip3 install --no-cache --upgrade pip streamlink
+
+## Add debian armhf/32bit libs for TwitchDownloaderCLI to work.
+RUN apt-get install libc6:armhf zlib1g:armhf gcc:armhf libicu-dev:armhf libfontconfig1:armhf -y
+
+# Install chat-downloader
+COPY --from=build-stage-02 /tmp/chat-downloader /tmp/chat-downloader
+RUN cd /tmp/chat-downloader && python3 setup.py install && cd .. && rm -rf chat-downloader
+
+# Inter font install
+ENV INTER_PATH "/tmp/Inter Desktop/Inter-Regular.otf"
+COPY --from=build-stage-02 ${INTER_PATH} /tmp/
+RUN mkdir -p /usr/share/fonts/opentype/ && install -m644 /tmp/Inter-Regular.otf /usr/share/fonts/opentype/Inter.otf && rm ./tmp/Inter-Regular.otf && fc-cache -fv
+
+# Install fallback fonts for chat rendering
+RUN apt-get install xfonts-terminus fonts-inconsolata fonts-dejavu fonts-dejavu-extra fonts-noto fonts-noto-cjk fonts-font-awesome fonts-noto-extra fonts-noto-core -y
+
+RUN chmod 644 /usr/share/fonts/*
+
+# TwitchDownloaderCLI
+COPY --from=build-stage-02 /tmp/TwitchDownloaderCLI /usr/local/bin/
+RUN chmod +x /usr/local/bin/TwitchDownloaderCLI
+
+COPY --from=build-stage-01 /app/ganymede-api .
+
+CMD ["./ganymede-api"]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Feel free to use an existing Postgres database container and Nginx container if 
 
 1. Download a copy of the `docker-compose.yml` file and `nginx.conf`.
 2. Edit the `docker-compose.yml` file modifying the environment variables, see [environment variables](https://github.com/Zibbp/ganymede#environment-variables).
+
+   - Add `-arm64` to the API and Frontend container images for an arm64 image.
+
 3. Run `docker compose up -d`.
 4. Visit the address and port you specified for the frontend and login with username: `admin` password: `ganymede`.
 5. Change the admin password _or_ create a new user, grant admin permissions on that user, and delete the admin user.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.3"
 services:
   ganymede-api:
     container_name: ganymede-api
+    # add "-arm64" for an arm64 image
     image: ghcr.io/zibbp/ganymede:latest
     restart: unless-stopped
     environment:
@@ -32,6 +33,7 @@ services:
       - 4800:4000
   ganymede-frontend:
     container_name: ganymede-frontend
+    # add "-arm64" for an arm64 image
     image: ghcr.io/zibbp/ganymede-frontend:latest
     restart: unless-stopped
     environment:


### PR DESCRIPTION
This file describes the standard way to build Gandymede on aarch64/arm64 for a Raspberry Pi 4 Model B Rev 1.2 with Raspberry Pi OS 64bit, using docker.

usage: `docker build -t ganymede-api -f Dockerfile.aarch64 .`