### PR TITLE
Fixes

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1429,6 +1429,57 @@ const docTemplate = `{
                 }
             }
         },
+        "/live/multiple": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyCookieAuth": []
+                    }
+                ],
+                "description": "This is useful to add multiple channels at once if they all have the same settings",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Live"
+                ],
+                "summary": "Add multiple watched channels at once",
+                "parameters": [
+                    {
+                        "description": "Add watched channel",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/http.AddMultipleWatchedChannelRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ent.Live"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/live/{id}": {
             "put": {
                 "security": [
@@ -2493,6 +2544,35 @@ const docTemplate = `{
                 "responses": {
                     "200": {
                         "description": "OK"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/twitch/categories": {
+            "get": {
+                "description": "Get a list of twitch categories",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "twitch"
+                ],
+                "summary": "Get a list of twitch categories",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/twitch.Category"
+                        }
                     },
                     "500": {
                         "description": "Internal Server Error",
@@ -4088,9 +4168,50 @@ const docTemplate = `{
                 }
             }
         },
+        "ent.LiveCategory": {
+            "type": "object",
+            "properties": {
+                "edges": {
+                    "description": "Edges holds the relations/edges for other nodes in the graph.\nThe values are being populated by the LiveCategoryQuery when eager-loading is set.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ent.LiveCategoryEdges"
+                        }
+                    ]
+                },
+                "id": {
+                    "description": "ID of the ent.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name holds the value of the \"name\" field.",
+                    "type": "string"
+                }
+            }
+        },
+        "ent.LiveCategoryEdges": {
+            "type": "object",
+            "properties": {
+                "live": {
+                    "description": "Live holds the value of the live edge.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ent.Live"
+                        }
+                    ]
+                }
+            }
+        },
         "ent.LiveEdges": {
             "type": "object",
             "properties": {
+                "categories": {
+                    "description": "Categories holds the value of the categories edge.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ent.LiveCategory"
+                    }
+                },
                 "channel": {
                     "description": "Channel holds the value of the channel edge.",
                     "allOf": [
@@ -4507,6 +4628,62 @@ const docTemplate = `{
                 }
             }
         },
+        "http.AddMultipleWatchedChannelRequest": {
+            "type": "object",
+            "required": [
+                "channel_id",
+                "resolution"
+            ],
+            "properties": {
+                "archive_chat": {
+                    "type": "boolean"
+                },
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "channel_id": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "download_archives": {
+                    "type": "boolean"
+                },
+                "download_highlights": {
+                    "type": "boolean"
+                },
+                "download_sub_only": {
+                    "type": "boolean"
+                },
+                "download_uploads": {
+                    "type": "boolean"
+                },
+                "render_chat": {
+                    "type": "boolean"
+                },
+                "resolution": {
+                    "type": "string",
+                    "enum": [
+                        "best",
+                        "source",
+                        "720p60",
+                        "480p30",
+                        "360p30",
+                        "160p30"
+                    ]
+                },
+                "watch_live": {
+                    "type": "boolean"
+                },
+                "watch_vod": {
+                    "type": "boolean"
+                }
+            }
+        },
         "http.AddVodToPlaylistRequest": {
             "type": "object",
             "required": [
@@ -4527,6 +4704,12 @@ const docTemplate = `{
             "properties": {
                 "archive_chat": {
                     "type": "boolean"
+                },
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "channel_id": {
                     "type": "string"
@@ -5219,6 +5402,12 @@ const docTemplate = `{
                 "archive_chat": {
                     "type": "boolean"
                 },
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "download_archives": {
                     "type": "boolean"
                 },
@@ -5250,6 +5439,17 @@ const docTemplate = `{
                 },
                 "watch_vod": {
                     "type": "boolean"
+                }
+            }
+        },
+        "twitch.Category": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1423,6 +1423,57 @@
                 }
             }
         },
+        "/live/multiple": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyCookieAuth": []
+                    }
+                ],
+                "description": "This is useful to add multiple channels at once if they all have the same settings",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Live"
+                ],
+                "summary": "Add multiple watched channels at once",
+                "parameters": [
+                    {
+                        "description": "Add watched channel",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/http.AddMultipleWatchedChannelRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ent.Live"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/live/{id}": {
             "put": {
                 "security": [
@@ -2487,6 +2538,35 @@
                 "responses": {
                     "200": {
                         "description": "OK"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/twitch/categories": {
+            "get": {
+                "description": "Get a list of twitch categories",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "twitch"
+                ],
+                "summary": "Get a list of twitch categories",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/twitch.Category"
+                        }
                     },
                     "500": {
                         "description": "Internal Server Error",
@@ -4082,9 +4162,50 @@
                 }
             }
         },
+        "ent.LiveCategory": {
+            "type": "object",
+            "properties": {
+                "edges": {
+                    "description": "Edges holds the relations/edges for other nodes in the graph.\nThe values are being populated by the LiveCategoryQuery when eager-loading is set.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ent.LiveCategoryEdges"
+                        }
+                    ]
+                },
+                "id": {
+                    "description": "ID of the ent.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name holds the value of the \"name\" field.",
+                    "type": "string"
+                }
+            }
+        },
+        "ent.LiveCategoryEdges": {
+            "type": "object",
+            "properties": {
+                "live": {
+                    "description": "Live holds the value of the live edge.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ent.Live"
+                        }
+                    ]
+                }
+            }
+        },
         "ent.LiveEdges": {
             "type": "object",
             "properties": {
+                "categories": {
+                    "description": "Categories holds the value of the categories edge.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ent.LiveCategory"
+                    }
+                },
                 "channel": {
                     "description": "Channel holds the value of the channel edge.",
                     "allOf": [
@@ -4501,6 +4622,62 @@
                 }
             }
         },
+        "http.AddMultipleWatchedChannelRequest": {
+            "type": "object",
+            "required": [
+                "channel_id",
+                "resolution"
+            ],
+            "properties": {
+                "archive_chat": {
+                    "type": "boolean"
+                },
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "channel_id": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "download_archives": {
+                    "type": "boolean"
+                },
+                "download_highlights": {
+                    "type": "boolean"
+                },
+                "download_sub_only": {
+                    "type": "boolean"
+                },
+                "download_uploads": {
+                    "type": "boolean"
+                },
+                "render_chat": {
+                    "type": "boolean"
+                },
+                "resolution": {
+                    "type": "string",
+                    "enum": [
+                        "best",
+                        "source",
+                        "720p60",
+                        "480p30",
+                        "360p30",
+                        "160p30"
+                    ]
+                },
+                "watch_live": {
+                    "type": "boolean"
+                },
+                "watch_vod": {
+                    "type": "boolean"
+                }
+            }
+        },
         "http.AddVodToPlaylistRequest": {
             "type": "object",
             "required": [
@@ -4521,6 +4698,12 @@
             "properties": {
                 "archive_chat": {
                     "type": "boolean"
+                },
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "channel_id": {
                     "type": "string"
@@ -5213,6 +5396,12 @@
                 "archive_chat": {
                     "type": "boolean"
                 },
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "download_archives": {
                     "type": "boolean"
                 },
@@ -5244,6 +5433,17 @@
                 },
                 "watch_vod": {
                     "type": "boolean"
+                }
+            }
+        },
+        "twitch.Category": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -357,8 +357,35 @@ definitions:
         description: Watch new VODs
         type: boolean
     type: object
+  ent.LiveCategory:
+    properties:
+      edges:
+        allOf:
+        - $ref: '#/definitions/ent.LiveCategoryEdges'
+        description: |-
+          Edges holds the relations/edges for other nodes in the graph.
+          The values are being populated by the LiveCategoryQuery when eager-loading is set.
+      id:
+        description: ID of the ent.
+        type: string
+      name:
+        description: Name holds the value of the "name" field.
+        type: string
+    type: object
+  ent.LiveCategoryEdges:
+    properties:
+      live:
+        allOf:
+        - $ref: '#/definitions/ent.Live'
+        description: Live holds the value of the live edge.
+    type: object
   ent.LiveEdges:
     properties:
+      categories:
+        description: Categories holds the value of the categories edge.
+        items:
+          $ref: '#/definitions/ent.LiveCategory'
+        type: array
       channel:
         allOf:
         - $ref: '#/definitions/ent.Channel'
@@ -634,6 +661,45 @@ definitions:
         - $ref: '#/definitions/ent.Queue'
         description: Queue holds the value of the queue edge.
     type: object
+  http.AddMultipleWatchedChannelRequest:
+    properties:
+      archive_chat:
+        type: boolean
+      categories:
+        items:
+          type: string
+        type: array
+      channel_id:
+        items:
+          type: string
+        type: array
+      download_archives:
+        type: boolean
+      download_highlights:
+        type: boolean
+      download_sub_only:
+        type: boolean
+      download_uploads:
+        type: boolean
+      render_chat:
+        type: boolean
+      resolution:
+        enum:
+        - best
+        - source
+        - 720p60
+        - 480p30
+        - 360p30
+        - 160p30
+        type: string
+      watch_live:
+        type: boolean
+      watch_vod:
+        type: boolean
+    required:
+    - channel_id
+    - resolution
+    type: object
   http.AddVodToPlaylistRequest:
     properties:
       vod_id:
@@ -645,6 +711,10 @@ definitions:
     properties:
       archive_chat:
         type: boolean
+      categories:
+        items:
+          type: string
+        type: array
       channel_id:
         type: string
       download_archives:
@@ -1115,6 +1185,10 @@ definitions:
     properties:
       archive_chat:
         type: boolean
+      categories:
+        items:
+          type: string
+        type: array
       download_archives:
         type: boolean
       download_highlights:
@@ -1140,6 +1214,13 @@ definitions:
         type: boolean
     required:
     - resolution
+    type: object
+  twitch.Category:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
     type: object
   twitch.Channel:
     properties:
@@ -2311,6 +2392,39 @@ paths:
       summary: Check watched channels
       tags:
       - Live
+  /live/multiple:
+    post:
+      consumes:
+      - application/json
+      description: This is useful to add multiple channels at once if they all have
+        the same settings
+      parameters:
+      - description: Add watched channel
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/http.AddMultipleWatchedChannelRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/ent.Live'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.ErrorResponse'
+      security:
+      - ApiKeyCookieAuth: []
+      summary: Add multiple watched channels at once
+      tags:
+      - Live
   /notification/test:
     get:
       consumes:
@@ -2927,6 +3041,25 @@ paths:
       summary: Start a task
       tags:
       - task
+  /twitch/categories:
+    get:
+      consumes:
+      - application/json
+      description: Get a list of twitch categories
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/twitch.Category'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.ErrorResponse'
+      summary: Get a list of twitch categories
+      tags:
+      - twitch
   /twitch/channel:
     get:
       consumes:

--- a/internal/transport/http/handler.go
+++ b/internal/transport/http/handler.go
@@ -227,6 +227,7 @@ func groupV1Routes(e *echo.Group, h *Handler) {
 	liveGroup := e.Group("/live")
 	liveGroup.GET("", h.GetLiveWatchedChannels, auth.GuardMiddleware, auth.GetUserMiddleware, auth.UserRoleMiddleware(utils.EditorRole))
 	liveGroup.POST("", h.AddLiveWatchedChannel, auth.GuardMiddleware, auth.GetUserMiddleware, auth.UserRoleMiddleware(utils.EditorRole))
+	liveGroup.POST("/multiple", h.AddMultipleLiveWatchedChannel, auth.GuardMiddleware, auth.GetUserMiddleware, auth.UserRoleMiddleware(utils.EditorRole))
 	liveGroup.PUT("/:id", h.UpdateLiveWatchedChannel, auth.GuardMiddleware, auth.GetUserMiddleware, auth.UserRoleMiddleware(utils.EditorRole))
 	liveGroup.DELETE("/:id", h.DeleteLiveWatchedChannel, auth.GuardMiddleware, auth.GetUserMiddleware, auth.UserRoleMiddleware(utils.EditorRole))
 	liveGroup.GET("/check", h.Check, auth.GuardMiddleware, auth.GetUserMiddleware, auth.UserRoleMiddleware(utils.EditorRole))

--- a/internal/transport/http/twitch.go
+++ b/internal/transport/http/twitch.go
@@ -96,7 +96,7 @@ func (h *Handler) GQLGetTwitchVideo(c echo.Context) error {
 //	@Tags			twitch
 //	@Accept			json
 //	@Produce		json
-//	@Success		200	{object}	twitch.Categories
+//	@Success		200	{object}	twitch.Category
 //	@Failure		500	{object}	utils.ErrorResponse
 //	@Router			/twitch/categories [get]
 func (h *Handler) GetTwitchCategories(c echo.Context) error {


### PR DESCRIPTION
Fixes for https://github.com/Zibbp/ganymede/issues/122

## Fixes
- Split the `getStreams` query into multiple requests with there are more than 100 channels to check. The Twitch API endpoint for this has a limit of 100 channel names per request.

## Features
- Add a `/live/multiple` route for adding multiple watched channels in a single request. A new route was created as to not break support with anything using the `/live` route. The frontend now allows the selection of multiple channels and will utilize this route.
    - This is useful for adding multiple watched channels at once if they all use the same settings.
![image](https://user-images.githubusercontent.com/21207065/221424025-a03cc740-95da-4116-9e29-07e24b6092ec.png)
