### PR TITLE
fix Dockerfile.aarch64

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -23,8 +23,22 @@ FROM arm64v8/debian AS production
 RUN dpkg --add-architecture armhf
 
 RUN apt-get update
-RUN apt-get install python3 python3-pip fontconfig icu-devtools python3-dev gcc g++ ffmpeg bash tzdata -y
+RUN apt-get install python3 python3-pip fontconfig icu-devtools python3-dev gcc libc-dev curl g++ ffmpeg bash tzdata -y
 RUN pip3 install --no-cache --upgrade pip streamlink
+
+## Installing su-exec in debain/ubuntu container.
+RUN  set -ex; \
+     \
+     curl -o /usr/local/bin/su-exec.c https://raw.githubusercontent.com/ncopa/su-exec/master/su-exec.c; \
+     \
+     gcc -Wall \
+         /usr/local/bin/su-exec.c -o/usr/local/bin/su-exec; \
+     chown root:root /usr/local/bin/su-exec; \
+     chmod 0755 /usr/local/bin/su-exec; \
+     rm /usr/local/bin/su-exec.c; \
+     \
+## Remove the su-exec dependency. It is no longer needed after building.
+     apt-get purge -y --auto-remove curl libc-dev
 
 # setup user
 RUN groupmod -g 1000 users && \


### PR DESCRIPTION
After the last changes from https://github.com/Zibbp/ganymede/pull/158 there was an error for su-exec because is was not found.
It seems that su-exec is not available in the normal apt-get repository for debain/ubunut.
So i add support to build it from source https://github.com/ncopa/su-exec.
After these changes PUID= and PGID= is working flawless and the container starts up normally again.