### PR TITLE
feat(vod): support deleting files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,7 @@
 {
   "build": { "dockerfile": "Dockerfile" },
   "features": {
-    // "ghcr.io/devcontainers/features/node:1": {
-    //   "version": "latest"
-    // },
-    // "ghcr.io/devcontainers/features/python:1": {
-    //   "version": "latest"
-    // }
+    "ghcr.io/eitsupi/devcontainer-features/go-task:1": {}
   },
   "customizations": {
     "vscode": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3302,6 +3302,12 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Delete files",
+                        "name": "delete_files",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -5776,6 +5782,8 @@ var SwaggerInfo = &swag.Spec{
 	Description:      "Authentication is handled using JWT tokens. The tokens are set as access-token and refresh-token cookies.\nFor information regarding which role is authorized for which endpoint, see the http handler https://github.com/Zibbp/ganymede/blob/main/internal/transport/http/handler.go.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
+	LeftDelim:        "{{",
+	RightDelim:       "}}",
 }
 
 func init() {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3295,6 +3295,12 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Delete files",
+                        "name": "delete_files",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3366,6 +3366,10 @@ paths:
         name: id
         required: true
         type: string
+      - description: Delete files
+        in: query
+        name: delete_files
+        type: string
       produces:
       - application/json
       responses:

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.15.0
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/viper v1.15.0
-	github.com/swaggo/swag v1.8.12
+	github.com/swaggo/swag v1.16.1
 	golang.org/x/crypto v0.8.0
 	golang.org/x/oauth2 v0.7.0
 	gopkg.in/square/go-jose.v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,8 @@ github.com/swaggo/files/v2 v2.0.0 h1:hmAt8Dkynw7Ssz46F6pn8ok6YmGZqHSVLZ+HQM7i0kw
 github.com/swaggo/files/v2 v2.0.0/go.mod h1:24kk2Y9NYEJ5lHuCra6iVwkMjIekMCaFq/0JQj66kyM=
 github.com/swaggo/swag v1.8.12 h1:pctzkNPu0AlQP2royqX3apjKCQonAnf7KGoxeO4y64w=
 github.com/swaggo/swag v1.8.12/go.mod h1:lNfm6Gg+oAq3zRJQNEMBE66LIJKM44mxFqhEEgy2its=
+github.com/swaggo/swag v1.16.1 h1:fTNRhKstPKxcnoKsytm4sahr8FaYzUcT7i1/3nd/fBg=
+github.com/swaggo/swag v1.16.1/go.mod h1:9/LMvHycG3NFHfR6LwvikHv5iFvmPADQ359cKikGxto=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=

--- a/internal/transport/http/vod.go
+++ b/internal/transport/http/vod.go
@@ -21,7 +21,7 @@ type VodService interface {
 	GetVodsByChannel(c echo.Context, cUUID uuid.UUID) ([]*ent.Vod, error)
 	GetVod(vID uuid.UUID) (*ent.Vod, error)
 	GetVodWithChannel(vID uuid.UUID) (*ent.Vod, error)
-	DeleteVod(c echo.Context, vID uuid.UUID) error
+	DeleteVod(c echo.Context, vID uuid.UUID, deleteFiles bool) error
 	UpdateVod(c echo.Context, vID uuid.UUID, vod vod.Vod, cID uuid.UUID) (*ent.Vod, error)
 	SearchVods(c echo.Context, query string, limit int, offset int) (vod.Pagination, error)
 	GetVodPlaylists(c echo.Context, vID uuid.UUID) ([]*ent.Playlist, error)
@@ -203,6 +203,7 @@ func (h *Handler) GetVod(c echo.Context) error {
 //	@Accept			json
 //	@Produce		json
 //	@Param			id	path	string	true	"Vod ID"
+//	@Param			delete_files	query	string	false	"Delete files"
 //	@Success		200
 //	@Failure		400	{object}	utils.ErrorResponse
 //	@Failure		404	{object}	utils.ErrorResponse
@@ -214,7 +215,13 @@ func (h *Handler) DeleteVod(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
-	err = h.Service.VodService.DeleteVod(c, vID)
+	// get query param of delete_files if exists
+	deleteFiles := false
+	dF := c.QueryParam("delete_files")
+	if dF == "true" {
+		deleteFiles = true
+	}
+	err = h.Service.VodService.DeleteVod(c, vID, deleteFiles)
 	if err != nil {
 		if err.Error() == "vod not found" {
 			return echo.NewHTTPError(http.StatusNotFound, err.Error())


### PR DESCRIPTION
This PR supports deleting vod files **only**. Closes https://github.com/Zibbp/ganymede/issues/184

- when deleting a vod, there is now a "switch" to enable deleting the vod folder/files. 

![image](https://user-images.githubusercontent.com/21207065/235033799-a2e05279-a1de-4ba6-b632-a9d6c86f0eed.png)

- the "vod menu" has a delete item for admins

![image](https://user-images.githubusercontent.com/21207065/235034591-37af4ba7-aa9e-4177-b8c7-53e997bf4d3f.png)

