### PR TITLE
feat: video schedule interval

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ func NewService(store *database.Database) *Service {
 type Conf struct {
 	Debug               bool `json:"debug"`
 	LiveCheckInterval   int  `json:"live_check_interval_seconds"`
+	VideoCheckInterval  int  `json:"video_check_interval_minutes"`
 	ActiveQueueItems    int  `json:"active_queue_items"`
 	OAuthEnabled        bool `json:"oauth_enabled"`
 	RegistrationEnabled bool `json:"registration_enabled"`
@@ -86,6 +87,7 @@ func NewConfig() {
 
 	viper.SetDefault("debug", false)
 	viper.SetDefault("live_check_interval_seconds", 300)
+	viper.SetDefault("video_check_interval_minutes", 180)
 	viper.SetDefault("active_queue_items", 2)
 	viper.SetDefault("oauth_enabled", false)
 	viper.SetDefault("registration_enabled", true)
@@ -371,6 +373,9 @@ func refreshConfig(configPath string) {
 		viper.Set("livestream.proxy_whitelist", []string{
 			"",
 		})
+	}
+	if !viper.IsSet("video_check_interval_minutes") {
+		viper.Set("video_check_interval_minutes", 180)
 	}
 
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -139,7 +139,10 @@ func (s *Service) checkLiveStreamSchedule(scheduler *gocron.Scheduler) {
 
 func (s *Service) checkWatchedChannelVideos(schedule *gocron.Scheduler) {
 	log.Info().Msg("setting up check watched channel videos schedule")
-	_, err := schedule.Every(1).Day().At("01:00").Do(func() {
+
+	configCheckVideoInterval := viper.GetInt("video_check_interval_minutes")
+	log.Debug().Msgf("setting video check interval to run every %d minutes", configCheckVideoInterval)
+	_, err := schedule.Every(configCheckVideoInterval).Minutes().Do(func() {
 		log.Info().Msg("running check watched channel videos schedule")
 		s.LiveService.CheckVodWatchedChannels()
 	})


### PR DESCRIPTION
- Add a config option named `video_check_interval_minutes`. This allows the user to configure the interval in which channels are checked for videos to archive.
  - Defaults to 3 hours.