### PR TITLE
feat: local view count

### DIFF
--- a/ent/channel_create.go
+++ b/ent/channel_create.go
@@ -166,7 +166,7 @@ func (cc *ChannelCreate) Mutation() *ChannelMutation {
 // Save creates the Channel in the database.
 func (cc *ChannelCreate) Save(ctx context.Context) (*Channel, error) {
 	cc.defaults()
-	return withHooks[*Channel, ChannelMutation](ctx, cc.sqlSave, cc.mutation, cc.hooks)
+	return withHooks(ctx, cc.sqlSave, cc.mutation, cc.hooks)
 }
 
 // SaveX calls Save and panics if Save returns an error.

--- a/ent/channel_delete.go
+++ b/ent/channel_delete.go
@@ -27,7 +27,7 @@ func (cd *ChannelDelete) Where(ps ...predicate.Channel) *ChannelDelete {
 
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *ChannelDelete) Exec(ctx context.Context) (int, error) {
-	return withHooks[int, ChannelMutation](ctx, cd.sqlExec, cd.mutation, cd.hooks)
+	return withHooks(ctx, cd.sqlExec, cd.mutation, cd.hooks)
 }
 
 // ExecX is like Exec, but panics if an error occurs.

--- a/ent/channel_update.go
+++ b/ent/channel_update.go
@@ -196,7 +196,7 @@ func (cu *ChannelUpdate) RemoveLive(l ...*Live) *ChannelUpdate {
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (cu *ChannelUpdate) Save(ctx context.Context) (int, error) {
 	cu.defaults()
-	return withHooks[int, ChannelMutation](ctx, cu.sqlSave, cu.mutation, cu.hooks)
+	return withHooks(ctx, cu.sqlSave, cu.mutation, cu.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
@@ -556,7 +556,7 @@ func (cuo *ChannelUpdateOne) Select(field string, fields ...string) *ChannelUpda
 // Save executes the query and returns the updated Channel entity.
 func (cuo *ChannelUpdateOne) Save(ctx context.Context) (*Channel, error) {
 	cuo.defaults()
-	return withHooks[*Channel, ChannelMutation](ctx, cuo.sqlSave, cuo.mutation, cuo.hooks)
+	return withHooks(ctx, cuo.sqlSave, cuo.mutation, cuo.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.

--- a/ent/live_create.go
+++ b/ent/live_create.go
@@ -256,7 +256,7 @@ func (lc *LiveCreate) Mutation() *LiveMutation {
 // Save creates the Live in the database.
 func (lc *LiveCreate) Save(ctx context.Context) (*Live, error) {
 	lc.defaults()
-	return withHooks[*Live, LiveMutation](ctx, lc.sqlSave, lc.mutation, lc.hooks)
+	return withHooks(ctx, lc.sqlSave, lc.mutation, lc.hooks)
 }
 
 // SaveX calls Save and panics if Save returns an error.

--- a/ent/live_delete.go
+++ b/ent/live_delete.go
@@ -27,7 +27,7 @@ func (ld *LiveDelete) Where(ps ...predicate.Live) *LiveDelete {
 
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ld *LiveDelete) Exec(ctx context.Context) (int, error) {
-	return withHooks[int, LiveMutation](ctx, ld.sqlExec, ld.mutation, ld.hooks)
+	return withHooks(ctx, ld.sqlExec, ld.mutation, ld.hooks)
 }
 
 // ExecX is like Exec, but panics if an error occurs.

--- a/ent/live_update.go
+++ b/ent/live_update.go
@@ -258,7 +258,7 @@ func (lu *LiveUpdate) RemoveCategories(l ...*LiveCategory) *LiveUpdate {
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (lu *LiveUpdate) Save(ctx context.Context) (int, error) {
 	lu.defaults()
-	return withHooks[int, LiveMutation](ctx, lu.sqlSave, lu.mutation, lu.hooks)
+	return withHooks(ctx, lu.sqlSave, lu.mutation, lu.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
@@ -684,7 +684,7 @@ func (luo *LiveUpdateOne) Select(field string, fields ...string) *LiveUpdateOne 
 // Save executes the query and returns the updated Live entity.
 func (luo *LiveUpdateOne) Save(ctx context.Context) (*Live, error) {
 	luo.defaults()
-	return withHooks[*Live, LiveMutation](ctx, luo.sqlSave, luo.mutation, luo.hooks)
+	return withHooks(ctx, luo.sqlSave, luo.mutation, luo.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.

--- a/ent/livecategory_create.go
+++ b/ent/livecategory_create.go
@@ -63,7 +63,7 @@ func (lcc *LiveCategoryCreate) Mutation() *LiveCategoryMutation {
 // Save creates the LiveCategory in the database.
 func (lcc *LiveCategoryCreate) Save(ctx context.Context) (*LiveCategory, error) {
 	lcc.defaults()
-	return withHooks[*LiveCategory, LiveCategoryMutation](ctx, lcc.sqlSave, lcc.mutation, lcc.hooks)
+	return withHooks(ctx, lcc.sqlSave, lcc.mutation, lcc.hooks)
 }
 
 // SaveX calls Save and panics if Save returns an error.

--- a/ent/livecategory_delete.go
+++ b/ent/livecategory_delete.go
@@ -27,7 +27,7 @@ func (lcd *LiveCategoryDelete) Where(ps ...predicate.LiveCategory) *LiveCategory
 
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (lcd *LiveCategoryDelete) Exec(ctx context.Context) (int, error) {
-	return withHooks[int, LiveCategoryMutation](ctx, lcd.sqlExec, lcd.mutation, lcd.hooks)
+	return withHooks(ctx, lcd.sqlExec, lcd.mutation, lcd.hooks)
 }
 
 // ExecX is like Exec, but panics if an error occurs.

--- a/ent/livecategory_update.go
+++ b/ent/livecategory_update.go
@@ -59,7 +59,7 @@ func (lcu *LiveCategoryUpdate) ClearLive() *LiveCategoryUpdate {
 
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (lcu *LiveCategoryUpdate) Save(ctx context.Context) (int, error) {
-	return withHooks[int, LiveCategoryMutation](ctx, lcu.sqlSave, lcu.mutation, lcu.hooks)
+	return withHooks(ctx, lcu.sqlSave, lcu.mutation, lcu.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
@@ -199,7 +199,7 @@ func (lcuo *LiveCategoryUpdateOne) Select(field string, fields ...string) *LiveC
 
 // Save executes the query and returns the updated LiveCategory entity.
 func (lcuo *LiveCategoryUpdateOne) Save(ctx context.Context) (*LiveCategory, error) {
-	return withHooks[*LiveCategory, LiveCategoryMutation](ctx, lcuo.sqlSave, lcuo.mutation, lcuo.hooks)
+	return withHooks(ctx, lcuo.sqlSave, lcuo.mutation, lcuo.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -201,6 +201,7 @@ var (
 		{Name: "folder_name", Type: field.TypeString, Nullable: true},
 		{Name: "file_name", Type: field.TypeString, Nullable: true},
 		{Name: "locked", Type: field.TypeBool, Default: false},
+		{Name: "local_views", Type: field.TypeInt, Default: 0},
 		{Name: "streamed_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "created_at", Type: field.TypeTime},
@@ -214,7 +215,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "vods_channels_vods",
-				Columns:    []*schema.Column{VodsColumns[22]},
+				Columns:    []*schema.Column{VodsColumns[23]},
 				RefColumns: []*schema.Column{ChannelsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -6891,6 +6891,8 @@ type VodMutation struct {
 	folder_name        *string
 	file_name          *string
 	locked             *bool
+	local_views        *int
+	addlocal_views     *int
 	streamed_at        *time.Time
 	updated_at         *time.Time
 	created_at         *time.Time
@@ -7803,6 +7805,62 @@ func (m *VodMutation) ResetLocked() {
 	m.locked = nil
 }
 
+// SetLocalViews sets the "local_views" field.
+func (m *VodMutation) SetLocalViews(i int) {
+	m.local_views = &i
+	m.addlocal_views = nil
+}
+
+// LocalViews returns the value of the "local_views" field in the mutation.
+func (m *VodMutation) LocalViews() (r int, exists bool) {
+	v := m.local_views
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldLocalViews returns the old "local_views" field's value of the Vod entity.
+// If the Vod object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *VodMutation) OldLocalViews(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldLocalViews is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldLocalViews requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldLocalViews: %w", err)
+	}
+	return oldValue.LocalViews, nil
+}
+
+// AddLocalViews adds i to the "local_views" field.
+func (m *VodMutation) AddLocalViews(i int) {
+	if m.addlocal_views != nil {
+		*m.addlocal_views += i
+	} else {
+		m.addlocal_views = &i
+	}
+}
+
+// AddedLocalViews returns the value that was added to the "local_views" field in this mutation.
+func (m *VodMutation) AddedLocalViews() (r int, exists bool) {
+	v := m.addlocal_views
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetLocalViews resets all changes to the "local_views" field.
+func (m *VodMutation) ResetLocalViews() {
+	m.local_views = nil
+	m.addlocal_views = nil
+}
+
 // SetStreamedAt sets the "streamed_at" field.
 func (m *VodMutation) SetStreamedAt(t time.Time) {
 	m.streamed_at = &t
@@ -8077,7 +8135,7 @@ func (m *VodMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *VodMutation) Fields() []string {
-	fields := make([]string, 0, 21)
+	fields := make([]string, 0, 22)
 	if m.ext_id != nil {
 		fields = append(fields, vod.FieldExtID)
 	}
@@ -8132,6 +8190,9 @@ func (m *VodMutation) Fields() []string {
 	if m.locked != nil {
 		fields = append(fields, vod.FieldLocked)
 	}
+	if m.local_views != nil {
+		fields = append(fields, vod.FieldLocalViews)
+	}
 	if m.streamed_at != nil {
 		fields = append(fields, vod.FieldStreamedAt)
 	}
@@ -8185,6 +8246,8 @@ func (m *VodMutation) Field(name string) (ent.Value, bool) {
 		return m.FileName()
 	case vod.FieldLocked:
 		return m.Locked()
+	case vod.FieldLocalViews:
+		return m.LocalViews()
 	case vod.FieldStreamedAt:
 		return m.StreamedAt()
 	case vod.FieldUpdatedAt:
@@ -8236,6 +8299,8 @@ func (m *VodMutation) OldField(ctx context.Context, name string) (ent.Value, err
 		return m.OldFileName(ctx)
 	case vod.FieldLocked:
 		return m.OldLocked(ctx)
+	case vod.FieldLocalViews:
+		return m.OldLocalViews(ctx)
 	case vod.FieldStreamedAt:
 		return m.OldStreamedAt(ctx)
 	case vod.FieldUpdatedAt:
@@ -8377,6 +8442,13 @@ func (m *VodMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetLocked(v)
 		return nil
+	case vod.FieldLocalViews:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetLocalViews(v)
+		return nil
 	case vod.FieldStreamedAt:
 		v, ok := value.(time.Time)
 		if !ok {
@@ -8412,6 +8484,9 @@ func (m *VodMutation) AddedFields() []string {
 	if m.addviews != nil {
 		fields = append(fields, vod.FieldViews)
 	}
+	if m.addlocal_views != nil {
+		fields = append(fields, vod.FieldLocalViews)
+	}
 	return fields
 }
 
@@ -8424,6 +8499,8 @@ func (m *VodMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedDuration()
 	case vod.FieldViews:
 		return m.AddedViews()
+	case vod.FieldLocalViews:
+		return m.AddedLocalViews()
 	}
 	return nil, false
 }
@@ -8446,6 +8523,13 @@ func (m *VodMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddViews(v)
+		return nil
+	case vod.FieldLocalViews:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddLocalViews(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Vod numeric field %s", name)
@@ -8578,6 +8662,9 @@ func (m *VodMutation) ResetField(name string) error {
 		return nil
 	case vod.FieldLocked:
 		m.ResetLocked()
+		return nil
+	case vod.FieldLocalViews:
+		m.ResetLocalViews()
 		return nil
 	case vod.FieldStreamedAt:
 		m.ResetStreamedAt()

--- a/ent/playback_create.go
+++ b/ent/playback_create.go
@@ -115,7 +115,7 @@ func (pc *PlaybackCreate) Mutation() *PlaybackMutation {
 // Save creates the Playback in the database.
 func (pc *PlaybackCreate) Save(ctx context.Context) (*Playback, error) {
 	pc.defaults()
-	return withHooks[*Playback, PlaybackMutation](ctx, pc.sqlSave, pc.mutation, pc.hooks)
+	return withHooks(ctx, pc.sqlSave, pc.mutation, pc.hooks)
 }
 
 // SaveX calls Save and panics if Save returns an error.

--- a/ent/playback_delete.go
+++ b/ent/playback_delete.go
@@ -27,7 +27,7 @@ func (pd *PlaybackDelete) Where(ps ...predicate.Playback) *PlaybackDelete {
 
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (pd *PlaybackDelete) Exec(ctx context.Context) (int, error) {
-	return withHooks[int, PlaybackMutation](ctx, pd.sqlExec, pd.mutation, pd.hooks)
+	return withHooks(ctx, pd.sqlExec, pd.mutation, pd.hooks)
 }
 
 // ExecX is like Exec, but panics if an error occurs.

--- a/ent/playback_update.go
+++ b/ent/playback_update.go
@@ -97,7 +97,7 @@ func (pu *PlaybackUpdate) Mutation() *PlaybackMutation {
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (pu *PlaybackUpdate) Save(ctx context.Context) (int, error) {
 	pu.defaults()
-	return withHooks[int, PlaybackMutation](ctx, pu.sqlSave, pu.mutation, pu.hooks)
+	return withHooks(ctx, pu.sqlSave, pu.mutation, pu.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
@@ -273,7 +273,7 @@ func (puo *PlaybackUpdateOne) Select(field string, fields ...string) *PlaybackUp
 // Save executes the query and returns the updated Playback entity.
 func (puo *PlaybackUpdateOne) Save(ctx context.Context) (*Playback, error) {
 	puo.defaults()
-	return withHooks[*Playback, PlaybackMutation](ctx, puo.sqlSave, puo.mutation, puo.hooks)
+	return withHooks(ctx, puo.sqlSave, puo.mutation, puo.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.

--- a/ent/playlist_create.go
+++ b/ent/playlist_create.go
@@ -124,7 +124,7 @@ func (pc *PlaylistCreate) Mutation() *PlaylistMutation {
 // Save creates the Playlist in the database.
 func (pc *PlaylistCreate) Save(ctx context.Context) (*Playlist, error) {
 	pc.defaults()
-	return withHooks[*Playlist, PlaylistMutation](ctx, pc.sqlSave, pc.mutation, pc.hooks)
+	return withHooks(ctx, pc.sqlSave, pc.mutation, pc.hooks)
 }
 
 // SaveX calls Save and panics if Save returns an error.

--- a/ent/playlist_delete.go
+++ b/ent/playlist_delete.go
@@ -27,7 +27,7 @@ func (pd *PlaylistDelete) Where(ps ...predicate.Playlist) *PlaylistDelete {
 
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (pd *PlaylistDelete) Exec(ctx context.Context) (int, error) {
-	return withHooks[int, PlaylistMutation](ctx, pd.sqlExec, pd.mutation, pd.hooks)
+	return withHooks(ctx, pd.sqlExec, pd.mutation, pd.hooks)
 }
 
 // ExecX is like Exec, but panics if an error occurs.

--- a/ent/playlist_update.go
+++ b/ent/playlist_update.go
@@ -126,7 +126,7 @@ func (pu *PlaylistUpdate) RemoveVods(v ...*Vod) *PlaylistUpdate {
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (pu *PlaylistUpdate) Save(ctx context.Context) (int, error) {
 	pu.defaults()
-	return withHooks[int, PlaylistMutation](ctx, pu.sqlSave, pu.mutation, pu.hooks)
+	return withHooks(ctx, pu.sqlSave, pu.mutation, pu.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
@@ -360,7 +360,7 @@ func (puo *PlaylistUpdateOne) Select(field string, fields ...string) *PlaylistUp
 // Save executes the query and returns the updated Playlist entity.
 func (puo *PlaylistUpdateOne) Save(ctx context.Context) (*Playlist, error) {
 	puo.defaults()
-	return withHooks[*Playlist, PlaylistMutation](ctx, puo.sqlSave, puo.mutation, puo.hooks)
+	return withHooks(ctx, puo.sqlSave, puo.mutation, puo.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.

--- a/ent/queue_create.go
+++ b/ent/queue_create.go
@@ -325,7 +325,7 @@ func (qc *QueueCreate) Mutation() *QueueMutation {
 // Save creates the Queue in the database.
 func (qc *QueueCreate) Save(ctx context.Context) (*Queue, error) {
 	qc.defaults()
-	return withHooks[*Queue, QueueMutation](ctx, qc.sqlSave, qc.mutation, qc.hooks)
+	return withHooks(ctx, qc.sqlSave, qc.mutation, qc.hooks)
 }
 
 // SaveX calls Save and panics if Save returns an error.

--- a/ent/queue_delete.go
+++ b/ent/queue_delete.go
@@ -27,7 +27,7 @@ func (qd *QueueDelete) Where(ps ...predicate.Queue) *QueueDelete {
 
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (qd *QueueDelete) Exec(ctx context.Context) (int, error) {
-	return withHooks[int, QueueMutation](ctx, qd.sqlExec, qd.mutation, qd.hooks)
+	return withHooks(ctx, qd.sqlExec, qd.mutation, qd.hooks)
 }
 
 // ExecX is like Exec, but panics if an error occurs.

--- a/ent/queue_update.go
+++ b/ent/queue_update.go
@@ -372,7 +372,7 @@ func (qu *QueueUpdate) ClearVod() *QueueUpdate {
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (qu *QueueUpdate) Save(ctx context.Context) (int, error) {
 	qu.defaults()
-	return withHooks[int, QueueMutation](ctx, qu.sqlSave, qu.mutation, qu.hooks)
+	return withHooks(ctx, qu.sqlSave, qu.mutation, qu.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
@@ -968,7 +968,7 @@ func (quo *QueueUpdateOne) Select(field string, fields ...string) *QueueUpdateOn
 // Save executes the query and returns the updated Queue entity.
 func (quo *QueueUpdateOne) Save(ctx context.Context) (*Queue, error) {
 	quo.defaults()
-	return withHooks[*Queue, QueueMutation](ctx, quo.sqlSave, quo.mutation, quo.hooks)
+	return withHooks(ctx, quo.sqlSave, quo.mutation, quo.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -234,18 +234,22 @@ func init() {
 	vodDescLocked := vodFields[18].Descriptor()
 	// vod.DefaultLocked holds the default value on creation for the locked field.
 	vod.DefaultLocked = vodDescLocked.Default.(bool)
+	// vodDescLocalViews is the schema descriptor for local_views field.
+	vodDescLocalViews := vodFields[19].Descriptor()
+	// vod.DefaultLocalViews holds the default value on creation for the local_views field.
+	vod.DefaultLocalViews = vodDescLocalViews.Default.(int)
 	// vodDescStreamedAt is the schema descriptor for streamed_at field.
-	vodDescStreamedAt := vodFields[19].Descriptor()
+	vodDescStreamedAt := vodFields[20].Descriptor()
 	// vod.DefaultStreamedAt holds the default value on creation for the streamed_at field.
 	vod.DefaultStreamedAt = vodDescStreamedAt.Default.(func() time.Time)
 	// vodDescUpdatedAt is the schema descriptor for updated_at field.
-	vodDescUpdatedAt := vodFields[20].Descriptor()
+	vodDescUpdatedAt := vodFields[21].Descriptor()
 	// vod.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	vod.DefaultUpdatedAt = vodDescUpdatedAt.Default.(func() time.Time)
 	// vod.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	vod.UpdateDefaultUpdatedAt = vodDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// vodDescCreatedAt is the schema descriptor for created_at field.
-	vodDescCreatedAt := vodFields[21].Descriptor()
+	vodDescCreatedAt := vodFields[22].Descriptor()
 	// vod.DefaultCreatedAt holds the default value on creation for the created_at field.
 	vod.DefaultCreatedAt = vodDescCreatedAt.Default.(func() time.Time)
 	// vodDescID is the schema descriptor for id field.

--- a/ent/runtime/runtime.go
+++ b/ent/runtime/runtime.go
@@ -5,6 +5,6 @@ package runtime
 // The schema-stitching logic is generated in github.com/zibbp/ganymede/ent/runtime.go
 
 const (
-	Version = "v0.12.2"                                         // Version of ent codegen.
-	Sum     = "h1:Ndl/JvCX76xCtUDlrUfMnOKBRodAtxE5yfGYxjbOxmM=" // Sum of ent codegen.
+	Version = "v0.12.3"                                         // Version of ent codegen.
+	Sum     = "h1:N5lO2EOrHpCH5HYfiMOCHYbo+oh5M8GjT0/cx5x6xkk=" // Sum of ent codegen.
 )

--- a/ent/schema/vod.go
+++ b/ent/schema/vod.go
@@ -37,6 +37,7 @@ func (Vod) Fields() []ent.Field {
 		field.String("folder_name").Optional(),
 		field.String("file_name").Optional(),
 		field.Bool("locked").Default(false),
+		field.Int("local_views").Default(0),
 		field.Time("streamed_at").Default(time.Now).Comment("The time the VOD was streamed."),
 		field.Time("updated_at").Default(time.Now).UpdateDefault(time.Now),
 		field.Time("created_at").Default(time.Now).Immutable(),

--- a/ent/twitchcategory_create.go
+++ b/ent/twitchcategory_create.go
@@ -99,7 +99,7 @@ func (tcc *TwitchCategoryCreate) Mutation() *TwitchCategoryMutation {
 // Save creates the TwitchCategory in the database.
 func (tcc *TwitchCategoryCreate) Save(ctx context.Context) (*TwitchCategory, error) {
 	tcc.defaults()
-	return withHooks[*TwitchCategory, TwitchCategoryMutation](ctx, tcc.sqlSave, tcc.mutation, tcc.hooks)
+	return withHooks(ctx, tcc.sqlSave, tcc.mutation, tcc.hooks)
 }
 
 // SaveX calls Save and panics if Save returns an error.

--- a/ent/twitchcategory_delete.go
+++ b/ent/twitchcategory_delete.go
@@ -27,7 +27,7 @@ func (tcd *TwitchCategoryDelete) Where(ps ...predicate.TwitchCategory) *TwitchCa
 
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (tcd *TwitchCategoryDelete) Exec(ctx context.Context) (int, error) {
-	return withHooks[int, TwitchCategoryMutation](ctx, tcd.sqlExec, tcd.mutation, tcd.hooks)
+	return withHooks(ctx, tcd.sqlExec, tcd.mutation, tcd.hooks)
 }
 
 // ExecX is like Exec, but panics if an error occurs.

--- a/ent/twitchcategory_update.go
+++ b/ent/twitchcategory_update.go
@@ -88,7 +88,7 @@ func (tcu *TwitchCategoryUpdate) Mutation() *TwitchCategoryMutation {
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (tcu *TwitchCategoryUpdate) Save(ctx context.Context) (int, error) {
 	tcu.defaults()
-	return withHooks[int, TwitchCategoryMutation](ctx, tcu.sqlSave, tcu.mutation, tcu.hooks)
+	return withHooks(ctx, tcu.sqlSave, tcu.mutation, tcu.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
@@ -241,7 +241,7 @@ func (tcuo *TwitchCategoryUpdateOne) Select(field string, fields ...string) *Twi
 // Save executes the query and returns the updated TwitchCategory entity.
 func (tcuo *TwitchCategoryUpdateOne) Save(ctx context.Context) (*TwitchCategory, error) {
 	tcuo.defaults()
-	return withHooks[*TwitchCategory, TwitchCategoryMutation](ctx, tcuo.sqlSave, tcuo.mutation, tcuo.hooks)
+	return withHooks(ctx, tcuo.sqlSave, tcuo.mutation, tcuo.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.

--- a/ent/user_create.go
+++ b/ent/user_create.go
@@ -151,7 +151,7 @@ func (uc *UserCreate) Mutation() *UserMutation {
 // Save creates the User in the database.
 func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 	uc.defaults()
-	return withHooks[*User, UserMutation](ctx, uc.sqlSave, uc.mutation, uc.hooks)
+	return withHooks(ctx, uc.sqlSave, uc.mutation, uc.hooks)
 }
 
 // SaveX calls Save and panics if Save returns an error.

--- a/ent/user_delete.go
+++ b/ent/user_delete.go
@@ -27,7 +27,7 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
-	return withHooks[int, UserMutation](ctx, ud.sqlExec, ud.mutation, ud.hooks)
+	return withHooks(ctx, ud.sqlExec, ud.mutation, ud.hooks)
 }
 
 // ExecX is like Exec, but panics if an error occurs.

--- a/ent/user_update.go
+++ b/ent/user_update.go
@@ -137,7 +137,7 @@ func (uu *UserUpdate) Mutation() *UserMutation {
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (uu *UserUpdate) Save(ctx context.Context) (int, error) {
 	uu.defaults()
-	return withHooks[int, UserMutation](ctx, uu.sqlSave, uu.mutation, uu.hooks)
+	return withHooks(ctx, uu.sqlSave, uu.mutation, uu.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
@@ -363,7 +363,7 @@ func (uuo *UserUpdateOne) Select(field string, fields ...string) *UserUpdateOne 
 // Save executes the query and returns the updated User entity.
 func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 	uuo.defaults()
-	return withHooks[*User, UserMutation](ctx, uuo.sqlSave, uuo.mutation, uuo.hooks)
+	return withHooks(ctx, uuo.sqlSave, uuo.mutation, uuo.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.

--- a/ent/vod.go
+++ b/ent/vod.go
@@ -57,6 +57,8 @@ type Vod struct {
 	FileName string `json:"file_name,omitempty"`
 	// Locked holds the value of the "locked" field.
 	Locked bool `json:"locked,omitempty"`
+	// LocalViews holds the value of the "local_views" field.
+	LocalViews int `json:"local_views,omitempty"`
 	// The time the VOD was streamed.
 	StreamedAt time.Time `json:"streamed_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
@@ -125,7 +127,7 @@ func (*Vod) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case vod.FieldProcessing, vod.FieldLocked:
 			values[i] = new(sql.NullBool)
-		case vod.FieldDuration, vod.FieldViews:
+		case vod.FieldDuration, vod.FieldViews, vod.FieldLocalViews:
 			values[i] = new(sql.NullInt64)
 		case vod.FieldExtID, vod.FieldPlatform, vod.FieldType, vod.FieldTitle, vod.FieldResolution, vod.FieldThumbnailPath, vod.FieldWebThumbnailPath, vod.FieldVideoPath, vod.FieldChatPath, vod.FieldChatVideoPath, vod.FieldInfoPath, vod.FieldCaptionPath, vod.FieldFolderName, vod.FieldFileName:
 			values[i] = new(sql.NullString)
@@ -264,6 +266,12 @@ func (v *Vod) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				v.Locked = value.Bool
 			}
+		case vod.FieldLocalViews:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field local_views", values[i])
+			} else if value.Valid {
+				v.LocalViews = int(value.Int64)
+			}
 		case vod.FieldStreamedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field streamed_at", values[i])
@@ -393,6 +401,9 @@ func (v *Vod) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("locked=")
 	builder.WriteString(fmt.Sprintf("%v", v.Locked))
+	builder.WriteString(", ")
+	builder.WriteString("local_views=")
+	builder.WriteString(fmt.Sprintf("%v", v.LocalViews))
 	builder.WriteString(", ")
 	builder.WriteString("streamed_at=")
 	builder.WriteString(v.StreamedAt.Format(time.ANSIC))

--- a/ent/vod/vod.go
+++ b/ent/vod/vod.go
@@ -53,6 +53,8 @@ const (
 	FieldFileName = "file_name"
 	// FieldLocked holds the string denoting the locked field in the database.
 	FieldLocked = "locked"
+	// FieldLocalViews holds the string denoting the local_views field in the database.
+	FieldLocalViews = "local_views"
 	// FieldStreamedAt holds the string denoting the streamed_at field in the database.
 	FieldStreamedAt = "streamed_at"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
@@ -109,6 +111,7 @@ var Columns = []string{
 	FieldFolderName,
 	FieldFileName,
 	FieldLocked,
+	FieldLocalViews,
 	FieldStreamedAt,
 	FieldUpdatedAt,
 	FieldCreatedAt,
@@ -150,6 +153,8 @@ var (
 	DefaultProcessing bool
 	// DefaultLocked holds the default value on creation for the "locked" field.
 	DefaultLocked bool
+	// DefaultLocalViews holds the default value on creation for the "local_views" field.
+	DefaultLocalViews int
 	// DefaultStreamedAt holds the default value on creation for the "streamed_at" field.
 	DefaultStreamedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -282,6 +287,11 @@ func ByFileName(opts ...sql.OrderTermOption) OrderOption {
 // ByLocked orders the results by the locked field.
 func ByLocked(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLocked, opts...).ToFunc()
+}
+
+// ByLocalViews orders the results by the local_views field.
+func ByLocalViews(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldLocalViews, opts...).ToFunc()
 }
 
 // ByStreamedAt orders the results by the streamed_at field.

--- a/ent/vod/where.go
+++ b/ent/vod/where.go
@@ -137,6 +137,11 @@ func Locked(v bool) predicate.Vod {
 	return predicate.Vod(sql.FieldEQ(FieldLocked, v))
 }
 
+// LocalViews applies equality check predicate on the "local_views" field. It's identical to LocalViewsEQ.
+func LocalViews(v int) predicate.Vod {
+	return predicate.Vod(sql.FieldEQ(FieldLocalViews, v))
+}
+
 // StreamedAt applies equality check predicate on the "streamed_at" field. It's identical to StreamedAtEQ.
 func StreamedAt(v time.Time) predicate.Vod {
 	return predicate.Vod(sql.FieldEQ(FieldStreamedAt, v))
@@ -1170,6 +1175,46 @@ func LockedEQ(v bool) predicate.Vod {
 // LockedNEQ applies the NEQ predicate on the "locked" field.
 func LockedNEQ(v bool) predicate.Vod {
 	return predicate.Vod(sql.FieldNEQ(FieldLocked, v))
+}
+
+// LocalViewsEQ applies the EQ predicate on the "local_views" field.
+func LocalViewsEQ(v int) predicate.Vod {
+	return predicate.Vod(sql.FieldEQ(FieldLocalViews, v))
+}
+
+// LocalViewsNEQ applies the NEQ predicate on the "local_views" field.
+func LocalViewsNEQ(v int) predicate.Vod {
+	return predicate.Vod(sql.FieldNEQ(FieldLocalViews, v))
+}
+
+// LocalViewsIn applies the In predicate on the "local_views" field.
+func LocalViewsIn(vs ...int) predicate.Vod {
+	return predicate.Vod(sql.FieldIn(FieldLocalViews, vs...))
+}
+
+// LocalViewsNotIn applies the NotIn predicate on the "local_views" field.
+func LocalViewsNotIn(vs ...int) predicate.Vod {
+	return predicate.Vod(sql.FieldNotIn(FieldLocalViews, vs...))
+}
+
+// LocalViewsGT applies the GT predicate on the "local_views" field.
+func LocalViewsGT(v int) predicate.Vod {
+	return predicate.Vod(sql.FieldGT(FieldLocalViews, v))
+}
+
+// LocalViewsGTE applies the GTE predicate on the "local_views" field.
+func LocalViewsGTE(v int) predicate.Vod {
+	return predicate.Vod(sql.FieldGTE(FieldLocalViews, v))
+}
+
+// LocalViewsLT applies the LT predicate on the "local_views" field.
+func LocalViewsLT(v int) predicate.Vod {
+	return predicate.Vod(sql.FieldLT(FieldLocalViews, v))
+}
+
+// LocalViewsLTE applies the LTE predicate on the "local_views" field.
+func LocalViewsLTE(v int) predicate.Vod {
+	return predicate.Vod(sql.FieldLTE(FieldLocalViews, v))
 }
 
 // StreamedAtEQ applies the EQ predicate on the "streamed_at" field.

--- a/ent/vod_create.go
+++ b/ent/vod_create.go
@@ -248,6 +248,20 @@ func (vc *VodCreate) SetNillableLocked(b *bool) *VodCreate {
 	return vc
 }
 
+// SetLocalViews sets the "local_views" field.
+func (vc *VodCreate) SetLocalViews(i int) *VodCreate {
+	vc.mutation.SetLocalViews(i)
+	return vc
+}
+
+// SetNillableLocalViews sets the "local_views" field if the given value is not nil.
+func (vc *VodCreate) SetNillableLocalViews(i *int) *VodCreate {
+	if i != nil {
+		vc.SetLocalViews(*i)
+	}
+	return vc
+}
+
 // SetStreamedAt sets the "streamed_at" field.
 func (vc *VodCreate) SetStreamedAt(t time.Time) *VodCreate {
 	vc.mutation.SetStreamedAt(t)
@@ -357,7 +371,7 @@ func (vc *VodCreate) Mutation() *VodMutation {
 // Save creates the Vod in the database.
 func (vc *VodCreate) Save(ctx context.Context) (*Vod, error) {
 	vc.defaults()
-	return withHooks[*Vod, VodMutation](ctx, vc.sqlSave, vc.mutation, vc.hooks)
+	return withHooks(ctx, vc.sqlSave, vc.mutation, vc.hooks)
 }
 
 // SaveX calls Save and panics if Save returns an error.
@@ -407,6 +421,10 @@ func (vc *VodCreate) defaults() {
 	if _, ok := vc.mutation.Locked(); !ok {
 		v := vod.DefaultLocked
 		vc.mutation.SetLocked(v)
+	}
+	if _, ok := vc.mutation.LocalViews(); !ok {
+		v := vod.DefaultLocalViews
+		vc.mutation.SetLocalViews(v)
 	}
 	if _, ok := vc.mutation.StreamedAt(); !ok {
 		v := vod.DefaultStreamedAt()
@@ -467,6 +485,9 @@ func (vc *VodCreate) check() error {
 	}
 	if _, ok := vc.mutation.Locked(); !ok {
 		return &ValidationError{Name: "locked", err: errors.New(`ent: missing required field "Vod.locked"`)}
+	}
+	if _, ok := vc.mutation.LocalViews(); !ok {
+		return &ValidationError{Name: "local_views", err: errors.New(`ent: missing required field "Vod.local_views"`)}
 	}
 	if _, ok := vc.mutation.StreamedAt(); !ok {
 		return &ValidationError{Name: "streamed_at", err: errors.New(`ent: missing required field "Vod.streamed_at"`)}
@@ -587,6 +608,10 @@ func (vc *VodCreate) createSpec() (*Vod, *sqlgraph.CreateSpec) {
 	if value, ok := vc.mutation.Locked(); ok {
 		_spec.SetField(vod.FieldLocked, field.TypeBool, value)
 		_node.Locked = value
+	}
+	if value, ok := vc.mutation.LocalViews(); ok {
+		_spec.SetField(vod.FieldLocalViews, field.TypeInt, value)
+		_node.LocalViews = value
 	}
 	if value, ok := vc.mutation.StreamedAt(); ok {
 		_spec.SetField(vod.FieldStreamedAt, field.TypeTime, value)
@@ -974,6 +999,24 @@ func (u *VodUpsert) SetLocked(v bool) *VodUpsert {
 // UpdateLocked sets the "locked" field to the value that was provided on create.
 func (u *VodUpsert) UpdateLocked() *VodUpsert {
 	u.SetExcluded(vod.FieldLocked)
+	return u
+}
+
+// SetLocalViews sets the "local_views" field.
+func (u *VodUpsert) SetLocalViews(v int) *VodUpsert {
+	u.Set(vod.FieldLocalViews, v)
+	return u
+}
+
+// UpdateLocalViews sets the "local_views" field to the value that was provided on create.
+func (u *VodUpsert) UpdateLocalViews() *VodUpsert {
+	u.SetExcluded(vod.FieldLocalViews)
+	return u
+}
+
+// AddLocalViews adds v to the "local_views" field.
+func (u *VodUpsert) AddLocalViews(v int) *VodUpsert {
+	u.Add(vod.FieldLocalViews, v)
 	return u
 }
 
@@ -1371,6 +1414,27 @@ func (u *VodUpsertOne) SetLocked(v bool) *VodUpsertOne {
 func (u *VodUpsertOne) UpdateLocked() *VodUpsertOne {
 	return u.Update(func(s *VodUpsert) {
 		s.UpdateLocked()
+	})
+}
+
+// SetLocalViews sets the "local_views" field.
+func (u *VodUpsertOne) SetLocalViews(v int) *VodUpsertOne {
+	return u.Update(func(s *VodUpsert) {
+		s.SetLocalViews(v)
+	})
+}
+
+// AddLocalViews adds v to the "local_views" field.
+func (u *VodUpsertOne) AddLocalViews(v int) *VodUpsertOne {
+	return u.Update(func(s *VodUpsert) {
+		s.AddLocalViews(v)
+	})
+}
+
+// UpdateLocalViews sets the "local_views" field to the value that was provided on create.
+func (u *VodUpsertOne) UpdateLocalViews() *VodUpsertOne {
+	return u.Update(func(s *VodUpsert) {
+		s.UpdateLocalViews()
 	})
 }
 
@@ -1935,6 +1999,27 @@ func (u *VodUpsertBulk) SetLocked(v bool) *VodUpsertBulk {
 func (u *VodUpsertBulk) UpdateLocked() *VodUpsertBulk {
 	return u.Update(func(s *VodUpsert) {
 		s.UpdateLocked()
+	})
+}
+
+// SetLocalViews sets the "local_views" field.
+func (u *VodUpsertBulk) SetLocalViews(v int) *VodUpsertBulk {
+	return u.Update(func(s *VodUpsert) {
+		s.SetLocalViews(v)
+	})
+}
+
+// AddLocalViews adds v to the "local_views" field.
+func (u *VodUpsertBulk) AddLocalViews(v int) *VodUpsertBulk {
+	return u.Update(func(s *VodUpsert) {
+		s.AddLocalViews(v)
+	})
+}
+
+// UpdateLocalViews sets the "local_views" field to the value that was provided on create.
+func (u *VodUpsertBulk) UpdateLocalViews() *VodUpsertBulk {
+	return u.Update(func(s *VodUpsert) {
+		s.UpdateLocalViews()
 	})
 }
 

--- a/ent/vod_delete.go
+++ b/ent/vod_delete.go
@@ -27,7 +27,7 @@ func (vd *VodDelete) Where(ps ...predicate.Vod) *VodDelete {
 
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (vd *VodDelete) Exec(ctx context.Context) (int, error) {
-	return withHooks[int, VodMutation](ctx, vd.sqlExec, vd.mutation, vd.hooks)
+	return withHooks(ctx, vd.sqlExec, vd.mutation, vd.hooks)
 }
 
 // ExecX is like Exec, but panics if an error occurs.

--- a/ent/vod_update.go
+++ b/ent/vod_update.go
@@ -315,6 +315,27 @@ func (vu *VodUpdate) SetNillableLocked(b *bool) *VodUpdate {
 	return vu
 }
 
+// SetLocalViews sets the "local_views" field.
+func (vu *VodUpdate) SetLocalViews(i int) *VodUpdate {
+	vu.mutation.ResetLocalViews()
+	vu.mutation.SetLocalViews(i)
+	return vu
+}
+
+// SetNillableLocalViews sets the "local_views" field if the given value is not nil.
+func (vu *VodUpdate) SetNillableLocalViews(i *int) *VodUpdate {
+	if i != nil {
+		vu.SetLocalViews(*i)
+	}
+	return vu
+}
+
+// AddLocalViews adds i to the "local_views" field.
+func (vu *VodUpdate) AddLocalViews(i int) *VodUpdate {
+	vu.mutation.AddLocalViews(i)
+	return vu
+}
+
 // SetStreamedAt sets the "streamed_at" field.
 func (vu *VodUpdate) SetStreamedAt(t time.Time) *VodUpdate {
 	vu.mutation.SetStreamedAt(t)
@@ -421,7 +442,7 @@ func (vu *VodUpdate) RemovePlaylists(p ...*Playlist) *VodUpdate {
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (vu *VodUpdate) Save(ctx context.Context) (int, error) {
 	vu.defaults()
-	return withHooks[int, VodMutation](ctx, vu.sqlSave, vu.mutation, vu.hooks)
+	return withHooks(ctx, vu.sqlSave, vu.mutation, vu.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
@@ -567,6 +588,12 @@ func (vu *VodUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := vu.mutation.Locked(); ok {
 		_spec.SetField(vod.FieldLocked, field.TypeBool, value)
+	}
+	if value, ok := vu.mutation.LocalViews(); ok {
+		_spec.SetField(vod.FieldLocalViews, field.TypeInt, value)
+	}
+	if value, ok := vu.mutation.AddedLocalViews(); ok {
+		_spec.AddField(vod.FieldLocalViews, field.TypeInt, value)
 	}
 	if value, ok := vu.mutation.StreamedAt(); ok {
 		_spec.SetField(vod.FieldStreamedAt, field.TypeTime, value)
@@ -979,6 +1006,27 @@ func (vuo *VodUpdateOne) SetNillableLocked(b *bool) *VodUpdateOne {
 	return vuo
 }
 
+// SetLocalViews sets the "local_views" field.
+func (vuo *VodUpdateOne) SetLocalViews(i int) *VodUpdateOne {
+	vuo.mutation.ResetLocalViews()
+	vuo.mutation.SetLocalViews(i)
+	return vuo
+}
+
+// SetNillableLocalViews sets the "local_views" field if the given value is not nil.
+func (vuo *VodUpdateOne) SetNillableLocalViews(i *int) *VodUpdateOne {
+	if i != nil {
+		vuo.SetLocalViews(*i)
+	}
+	return vuo
+}
+
+// AddLocalViews adds i to the "local_views" field.
+func (vuo *VodUpdateOne) AddLocalViews(i int) *VodUpdateOne {
+	vuo.mutation.AddLocalViews(i)
+	return vuo
+}
+
 // SetStreamedAt sets the "streamed_at" field.
 func (vuo *VodUpdateOne) SetStreamedAt(t time.Time) *VodUpdateOne {
 	vuo.mutation.SetStreamedAt(t)
@@ -1098,7 +1146,7 @@ func (vuo *VodUpdateOne) Select(field string, fields ...string) *VodUpdateOne {
 // Save executes the query and returns the updated Vod entity.
 func (vuo *VodUpdateOne) Save(ctx context.Context) (*Vod, error) {
 	vuo.defaults()
-	return withHooks[*Vod, VodMutation](ctx, vuo.sqlSave, vuo.mutation, vuo.hooks)
+	return withHooks(ctx, vuo.sqlSave, vuo.mutation, vuo.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
@@ -1261,6 +1309,12 @@ func (vuo *VodUpdateOne) sqlSave(ctx context.Context) (_node *Vod, err error) {
 	}
 	if value, ok := vuo.mutation.Locked(); ok {
 		_spec.SetField(vod.FieldLocked, field.TypeBool, value)
+	}
+	if value, ok := vuo.mutation.LocalViews(); ok {
+		_spec.SetField(vod.FieldLocalViews, field.TypeInt, value)
+	}
+	if value, ok := vuo.mutation.AddedLocalViews(); ok {
+		_spec.AddField(vod.FieldLocalViews, field.TypeInt, value)
 	}
 	if value, ok := vuo.mutation.StreamedAt(); ok {
 		_spec.SetField(vod.FieldStreamedAt, field.TypeTime, value)

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
 github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
@@ -236,6 +238,8 @@ github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTS
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
@@ -269,6 +273,8 @@ github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=
 github.com/spf13/cast v1.5.1/go.mod h1:b9PdjNptOpzXr7Rq1q9gJML/2cdGQAo69NKzQ10KN48=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/internal/playback/playback.go
+++ b/internal/playback/playback.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
 	"github.com/zibbp/ganymede/ent"
 	"github.com/zibbp/ganymede/ent/playback"
 	entPlayback "github.com/zibbp/ganymede/ent/playback"
@@ -166,4 +167,19 @@ func (s *Service) GetLastPlaybacks(c *auth.CustomContext, limit int) (*GetPlayba
 	}
 
 	return getPlaybackResp, nil
+}
+
+func (s *Service) StartPlayback(c echo.Context, videoId uuid.UUID) error {
+	video, err := s.Store.Client.Vod.Query().Where(entVod.ID(videoId)).WithChannel().Only(c.Request().Context())
+	if err != nil {
+		return fmt.Errorf("error getting video: %v", err)
+	}
+
+	// add a view to the video
+	err = s.Store.Client.Vod.UpdateOne(video).AddLocalViews(1).Exec(c.Request().Context())
+	if err != nil {
+		return fmt.Errorf("error adding view to video: %v", err)
+	}
+
+	return nil
 }

--- a/internal/transport/http/handler.go
+++ b/internal/transport/http/handler.go
@@ -247,6 +247,7 @@ func groupV1Routes(e *echo.Group, h *Handler) {
 	playbackGroup.POST("/status", h.UpdateStatus, auth.GuardMiddleware, auth.GetUserMiddleware)
 	playbackGroup.DELETE("/:id", h.DeleteProgress, auth.GuardMiddleware, auth.GetUserMiddleware)
 	playbackGroup.GET("/last", h.GetLastPlaybacks, auth.GuardMiddleware, auth.GetUserMiddleware)
+	playbackGroup.POST("/start", h.StartPlayback)
 
 	// Playlist
 	playlistGroup := e.Group("/playlist")

--- a/internal/transport/http/playback.go
+++ b/internal/transport/http/playback.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -18,6 +19,7 @@ type PlaybackService interface {
 	UpdateStatus(c *auth.CustomContext, vID uuid.UUID, status string) error
 	DeleteProgress(c *auth.CustomContext, vID uuid.UUID) error
 	GetLastPlaybacks(c *auth.CustomContext, limit int) (*playback.GetPlaybackResp, error)
+	StartPlayback(c echo.Context, videoId uuid.UUID) error
 }
 
 type UpdateProgressRequest struct {
@@ -181,4 +183,31 @@ func (h *Handler) GetLastPlaybacks(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, playbackEntries)
+}
+
+// StartPlayback godoc
+//
+//	@Summary		Start playback
+//	@Description	Adds a view to the video local view count
+//	@Tags			Playback
+//	@Accept			json
+//	@Produce		json
+//	@Param			id	path		string	true	"vod id"
+//	@Success		200	{object}	string
+//	@Failure		400	{object}	utils.ErrorResponse
+//	@Failure		500	{object}	utils.ErrorResponse
+//	@Router			/playback/start [post]
+func (h *Handler) StartPlayback(c echo.Context) error {
+	videoId, err := uuid.Parse(c.QueryParam("video_id"))
+	if err != nil {
+		fmt.Println(err)
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid video id")
+	}
+
+	err = h.Service.PlaybackService.StartPlayback(c, videoId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, "ok")
 }


### PR DESCRIPTION
- Add a `local_view` column to the `vod` schema.
- Add a `start` route to the playback group.
  - Will be invoked on every initial page load when viewing a video on the frontend (authenticated or unauthenticated).
  - Only includes incrementing the `local_video` count for now.