### PR TITLE
fix(archive): return and delete queue if no stream data

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -613,9 +613,17 @@ func (s *Service) TaskVodSaveLiveInfo(ch *ent.Channel, v *ent.Vod, q *ent.Queue,
 
 	if len(stream.Data) == 0 {
 		log.Error().Msg("stream data is empty")
+		// delete queue item
 		err := database.DB().Client.Queue.DeleteOne(q).Exec(context.Background())
 		if err != nil {
 			log.Error().Err(err).Msg("error deleting queue item")
+		}
+		// delete vod
+		fakeContext := echo.New().NewContext(nil, nil)
+		err = s.VodService.DeleteVod(fakeContext, v.ID, true)
+		if err != nil {
+			log.Error().Err(err).Msg("error deleting vod")
+			return fmt.Errorf("error deleting vod: %v", err)
 		}
 		return fmt.Errorf("stream data is empty")
 	}


### PR DESCRIPTION
Hopefully fixes #257 

A stream may have ended but the Twitch API hasn't updated yet. This causes a new archive to be created. When the first task runs (save livestream info) the Twitch API finally updates. This causes the task to fail as there is no stream data. This PR checks if there is stream data. If there isn't any data, the queue is stopped and deleted, along with the video.