### PR TITLE
feat: re-add database ssl support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,5 +37,5 @@
   ],
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/workspace",
-  "postAttachCommand": "make dev_setup"
+  "postAttachCommand": "sudo chown -R vscode:vscode /go && make dev_setup"
 }

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ river-webui:
 	curl -L https://github.com/riverqueue/riverui/releases/latest/download/riverui_linux_amd64.gz | gzip -d > /tmp/riverui
 	chmod +x /tmp/riverui
 	@export $(shell grep -v '^#' .env | xargs) && \
-	VITE_RIVER_API_BASE_URL=http://localhost:8080/api DATABASE_URL=postgres://$$DB_USER:$$DB_PASS@dev.tycho:$$DB_PORT/$$DB_NAME /tmp/riverui
+	VITE_RIVER_API_BASE_URL=http://localhost:8080/api DATABASE_URL=postgres://$$DB_USER:$$DB_PASS@$$DB_HOST:$$DB_PORT/$$DB_NAME /tmp/riverui

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	log.Info().Str("commit", utils.Commit).Str("build_time", utils.BuildTime).Msg("starting worker")
 
-	dbString := fmt.Sprintf("user=%s password=%s host=%s port=%s dbname=%s sslmode=%s", envAppConfig.DB_USER, envAppConfig.DB_PASS, envAppConfig.DB_HOST, envAppConfig.DB_PORT, envAppConfig.DB_NAME, envAppConfig.DB_SSL)
+	dbString := fmt.Sprintf("user=%s password=%s host=%s port=%s dbname=%s sslmode=%s sslrootcert=%s", envAppConfig.DB_USER, envAppConfig.DB_PASS, envAppConfig.DB_HOST, envAppConfig.DB_PORT, envAppConfig.DB_NAME, envAppConfig.DB_SSL, envAppConfig.DB_SSL_ROOT_CERT)
 
 	db := database.NewDatabase(ctx, database.DatabaseConnectionInput{
 		DBString: dbString,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - DB_PASS=PASSWORD
       - DB_NAME=ganymede-prd
       - DB_SSL=disable
+      #- DB_SSL_ROOT_CERT= # path to cert in the container if DB_SSL is not disabled
       - JWT_SECRET=SECRET # set as a random string
       - JWT_REFRESH_SECRET=SECRET # set as a random string
       - TWITCH_CLIENT_ID= # from your twitch application

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -24,35 +24,6 @@ type Database struct {
 	ConnPool *pgxpool.Pool
 }
 
-func InitializeDatabase(input DatabaseConnectionInput) {
-	client, err := ent.Open("postgres", input.DBString)
-
-	if err != nil {
-		log.Fatal().Err(err).Msg("error connecting to database")
-	}
-
-	if !input.IsWorker {
-		// Run auto migration
-		if err := client.Schema.Create(context.Background()); err != nil {
-			log.Fatal().Err(err).Msg("error running auto migration")
-		}
-		// check if any users exist
-		users, err := client.User.Query().All(context.Background())
-		if err != nil {
-			log.Panic().Err(err).Msg("error querying users")
-		}
-		// if no users exist, seed database
-		if len(users) == 0 {
-			// seed database
-			log.Debug().Msg("seeding database")
-			if err := seedDatabase(client); err != nil {
-				log.Panic().Err(err).Msg("error seeding database")
-			}
-		}
-	}
-	db = &Database{Client: client}
-}
-
 func DB() *Database {
 	return db
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -70,7 +70,7 @@ func SetupApplication(ctx context.Context) (*Application, error) {
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
 
-	dbString := fmt.Sprintf("user=%s password=%s host=%s port=%s dbname=%s sslmode=%s", envAppConfig.DB_USER, envAppConfig.DB_PASS, envAppConfig.DB_HOST, envAppConfig.DB_PORT, envAppConfig.DB_NAME, envAppConfig.DB_SSL)
+	dbString := fmt.Sprintf("user=%s password=%s host=%s port=%s dbname=%s sslmode=%s sslrootcert=%s", envAppConfig.DB_USER, envAppConfig.DB_PASS, envAppConfig.DB_HOST, envAppConfig.DB_PORT, envAppConfig.DB_NAME, envAppConfig.DB_SSL, envAppConfig.DB_SSL_ROOT_CERT)
 
 	db := database.NewDatabase(ctx, database.DatabaseConnectionInput{
 		DBString: dbString,


### PR DESCRIPTION
Re-add the ability to specify the `DB_SSL_ROOT_CERT` variable which is a path to a SSL certificate used to secure the postgres connection.