### PR TITLE
fix: max video age for watched channels

### DIFF
--- a/frontend/app/components/admin/watched/DrawerContent.tsx
+++ b/frontend/app/components/admin/watched/DrawerContent.tsx
@@ -59,7 +59,7 @@ const AdminWatchedChannelDrawerContent = ({ watchedChannel, mode, handleClose }:
       channel_id: watchedChannel?.edges.channel.id || "",
       render_chat: watchedChannel?.render_chat ?? true,
       download_sub_only: watchedChannel?.download_sub_only ?? false,
-      max_age: watchedChannel?.max_age || 7,
+      video_age: watchedChannel?.video_age || 0,
       apply_categories_to_live: watchedChannel?.apply_categories_to_live ?? false,
       watch_clips: watchedChannel?.watch_clips ?? false,
       clips_limit: watchedChannel?.clips_limit || 5,
@@ -121,7 +121,7 @@ const AdminWatchedChannelDrawerContent = ({ watchedChannel, mode, handleClose }:
           archive_chat: formValues.archive_chat,
           render_chat: formValues.render_chat,
           download_sub_only: formValues.download_sub_only,
-          max_age: formValues.max_age,
+          video_age: formValues.video_age,
           apply_categories_to_live: formValues.apply_categories_to_live,
           watch_clips: formValues.watch_clips,
           clips_limit: formValues.clips_limit,
@@ -162,7 +162,7 @@ const AdminWatchedChannelDrawerContent = ({ watchedChannel, mode, handleClose }:
           archive_chat: formValues.archive_chat,
           render_chat: formValues.render_chat,
           download_sub_only: formValues.download_sub_only,
-          max_age: formValues.max_age,
+          video_age: formValues.video_age,
           apply_categories_to_live: formValues.apply_categories_to_live,
           watch_clips: formValues.watch_clips,
           clips_limit: formValues.clips_limit,
@@ -360,8 +360,8 @@ const AdminWatchedChannelDrawerContent = ({ watchedChannel, mode, handleClose }:
           <NumberInput
             label="Max Video Age (days)"
             description="Archive videos that are not older than this number of days (0 to archive all)."
-            key={form.key('max_age')}
-            {...form.getInputProps('max_age')}
+            key={form.key('video_age')}
+            {...form.getInputProps('video_age')}
           />
 
           <Group mt={5}>

--- a/frontend/app/hooks/useWatchedChannels.ts
+++ b/frontend/app/hooks/useWatchedChannels.ts
@@ -18,7 +18,7 @@ export interface WatchedChannel {
   resolution: string;
   last_live: string;
   render_chat: boolean;
-  max_age: number;
+  video_age: number;
   apply_categories_to_live: boolean;
   watch_clips: boolean;
   clips_limit: number;
@@ -71,7 +71,7 @@ const editWatchedChannel = async (
     render_chat: watchedChannel.render_chat,
     download_sub_only: watchedChannel.download_sub_only,
     categories: categories,
-    max_age: watchedChannel.max_age,
+    video_age: watchedChannel.video_age,
     regex: watchedChannel.edges.title_regex,
     apply_categories_to_live: watchedChannel.apply_categories_to_live,
     watch_clips: watchedChannel.watch_clips,
@@ -99,7 +99,7 @@ const createWatchedChannel = async (
     render_chat: watchedChannel.render_chat,
     download_sub_only: watchedChannel.download_sub_only,
     categories: categories,
-    max_age: watchedChannel.max_age,
+    video_age: watchedChannel.video_age,
     regex: watchedChannel.edges.title_regex,
     apply_categories_to_live: watchedChannel.apply_categories_to_live,
     watch_clips: watchedChannel.watch_clips,

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -47,7 +47,7 @@ type Live struct {
 	DownloadSubOnly       bool                 `json:"download_sub_only"`
 	Categories            []string             `json:"categories"`
 	ApplyCategoriesToLive bool                 `json:"apply_categories_to_live"`
-	MaxAge                int64                `json:"max_age"`
+	VideoAge              int64                `json:"video_age"` // Restrict fetching videos to a certain age.
 	TitleRegex            []ent.LiveTitleRegex `json:"title_regex"`
 	WatchClips            bool                 `json:"watch_clips"`
 	ClipsLimit            int                  `json:"clips_limit"`
@@ -92,7 +92,7 @@ func (s *Service) AddLiveWatchedChannel(c echo.Context, liveDto Live) (*ent.Live
 		return nil, fmt.Errorf("channel already watched")
 	}
 
-	l, err := s.Store.Client.Live.Create().SetChannelID(liveDto.ID).SetWatchLive(liveDto.WatchLive).SetWatchVod(liveDto.WatchVod).SetDownloadArchives(liveDto.DownloadArchives).SetDownloadHighlights(liveDto.DownloadHighlights).SetDownloadUploads(liveDto.DownloadUploads).SetResolution(liveDto.Resolution).SetArchiveChat(liveDto.ArchiveChat).SetRenderChat(liveDto.RenderChat).SetDownloadSubOnly(liveDto.DownloadSubOnly).SetVideoAge(liveDto.MaxAge).SetApplyCategoriesToLive(liveDto.ApplyCategoriesToLive).SetWatchClips(liveDto.WatchClips).SetClipsLimit(liveDto.ClipsLimit).SetClipsIntervalDays(liveDto.ClipsIntervalDays).Save(c.Request().Context())
+	l, err := s.Store.Client.Live.Create().SetChannelID(liveDto.ID).SetWatchLive(liveDto.WatchLive).SetWatchVod(liveDto.WatchVod).SetDownloadArchives(liveDto.DownloadArchives).SetDownloadHighlights(liveDto.DownloadHighlights).SetDownloadUploads(liveDto.DownloadUploads).SetResolution(liveDto.Resolution).SetArchiveChat(liveDto.ArchiveChat).SetRenderChat(liveDto.RenderChat).SetDownloadSubOnly(liveDto.DownloadSubOnly).SetVideoAge(liveDto.VideoAge).SetApplyCategoriesToLive(liveDto.ApplyCategoriesToLive).SetWatchClips(liveDto.WatchClips).SetClipsLimit(liveDto.ClipsLimit).SetClipsIntervalDays(liveDto.ClipsIntervalDays).Save(c.Request().Context())
 	if err != nil {
 		return nil, fmt.Errorf("error adding watched channel: %v", err)
 	}
@@ -118,7 +118,7 @@ func (s *Service) AddLiveWatchedChannel(c echo.Context, liveDto Live) (*ent.Live
 }
 
 func (s *Service) UpdateLiveWatchedChannel(c echo.Context, liveDto Live) (*ent.Live, error) {
-	l, err := s.Store.Client.Live.UpdateOneID(liveDto.ID).SetWatchLive(liveDto.WatchLive).SetWatchVod(liveDto.WatchVod).SetDownloadArchives(liveDto.DownloadArchives).SetDownloadHighlights(liveDto.DownloadHighlights).SetDownloadUploads(liveDto.DownloadUploads).SetResolution(liveDto.Resolution).SetArchiveChat(liveDto.ArchiveChat).SetRenderChat(liveDto.RenderChat).SetDownloadSubOnly(liveDto.DownloadSubOnly).SetVideoAge(liveDto.MaxAge).SetApplyCategoriesToLive(liveDto.ApplyCategoriesToLive).SetClipsLimit(liveDto.ClipsLimit).SetClipsIntervalDays(liveDto.ClipsIntervalDays).SetWatchClips(liveDto.WatchClips).Save(c.Request().Context())
+	l, err := s.Store.Client.Live.UpdateOneID(liveDto.ID).SetWatchLive(liveDto.WatchLive).SetWatchVod(liveDto.WatchVod).SetDownloadArchives(liveDto.DownloadArchives).SetDownloadHighlights(liveDto.DownloadHighlights).SetDownloadUploads(liveDto.DownloadUploads).SetResolution(liveDto.Resolution).SetArchiveChat(liveDto.ArchiveChat).SetRenderChat(liveDto.RenderChat).SetDownloadSubOnly(liveDto.DownloadSubOnly).SetVideoAge(liveDto.VideoAge).SetApplyCategoriesToLive(liveDto.ApplyCategoriesToLive).SetClipsLimit(liveDto.ClipsLimit).SetClipsIntervalDays(liveDto.ClipsIntervalDays).SetWatchClips(liveDto.WatchClips).Save(c.Request().Context())
 	if err != nil {
 		return nil, fmt.Errorf("error updating watched channel: %v", err)
 	}

--- a/internal/transport/http/live.go
+++ b/internal/transport/http/live.go
@@ -32,7 +32,7 @@ type AddWatchedChannelRequest struct {
 	DownloadSubOnly       bool                `json:"download_sub_only" validate:"boolean"`
 	Categories            []string            `json:"categories"`
 	ApplyCategoriesToLive bool                `json:"apply_categories_to_live" validate:"boolean"`
-	MaxAge                int64               `json:"max_age"`
+	VideoAge              int64               `json:"video_age"` // retrict fetching videos to a certain age
 	Regex                 []AddLiveTitleRegex `json:"regex"`
 	WatchClips            bool                `json:"watch_clips" validate:"boolean"`
 	ClipsLimit            int                 `json:"clips_limit" validate:"number,gte=1"`
@@ -57,7 +57,7 @@ type UpdateWatchedChannelRequest struct {
 	DownloadSubOnly       bool                `json:"download_sub_only" validate:"boolean"`
 	Categories            []string            `json:"categories"`
 	ApplyCategoriesToLive bool                `json:"apply_categories_to_live" validate:"boolean"`
-	MaxAge                int64               `json:"max_age"`
+	VideoAge              int64               `json:"video_age"` // retrict fetching videos to a certain age
 	Regex                 []AddLiveTitleRegex `json:"regex"`
 	WatchClips            bool                `json:"watch_clips" validate:"boolean"`
 	ClipsLimit            int                 `json:"clips_limit" validate:"number,gte=1"`
@@ -147,7 +147,7 @@ func (h *Handler) AddLiveWatchedChannel(c echo.Context) error {
 		DownloadSubOnly:       ccr.DownloadSubOnly,
 		Categories:            ccr.Categories,
 		ApplyCategoriesToLive: ccr.ApplyCategoriesToLive,
-		MaxAge:                ccr.MaxAge,
+		VideoAge:              ccr.VideoAge,
 		WatchClips:            ccr.WatchClips,
 		ClipsLimit:            ccr.ClipsLimit,
 		ClipsIntervalDays:     ccr.ClipsIntervalDays,
@@ -217,7 +217,7 @@ func (h *Handler) UpdateLiveWatchedChannel(c echo.Context) error {
 		DownloadSubOnly:       ccr.DownloadSubOnly,
 		Categories:            ccr.Categories,
 		ApplyCategoriesToLive: ccr.ApplyCategoriesToLive,
-		MaxAge:                ccr.MaxAge,
+		VideoAge:              ccr.VideoAge,
 		WatchClips:            ccr.WatchClips,
 		ClipsLimit:            ccr.ClipsLimit,
 		ClipsIntervalDays:     ccr.ClipsIntervalDays,


### PR DESCRIPTION
Fixes https://github.com/Zibbp/ganymede/issues/554

Rename `max_age` to `video_age` to match what the database is. Also default to `0` to archive all videos.