### PR TITLE
feat(frontend): add locked video indicator

### DIFF
--- a/frontend/app/admin/blocked-videos/page.tsx
+++ b/frontend/app/admin/blocked-videos/page.tsx
@@ -13,6 +13,7 @@ import { BlockedVideo, useGetBlockedVideos } from "@/app/hooks/useBlockedVideos"
 import { useAxiosPrivate } from "@/app/hooks/useAxios";
 import DeleteBlockedVideoModalContent from "@/app/components/admin/blocked-videos/DeleteModalContent";
 import AdminBlockedVideosDrawerContent from "@/app/components/admin/blocked-videos/DrawerContent";
+import MultiDeleteBlockedVideoModalContent from "@/app/components/admin/blocked-videos/MultiDeleteModalContent";
 
 const AdminBlockedVideosPage = () => {
   useEffect(() => {
@@ -32,6 +33,10 @@ const AdminBlockedVideosPage = () => {
 
   const [blockedVideoDrawerOpened, { open: openBlockedVideoDrawer, close: closeBlockedVideoDrawer }] = useDisclosure(false);
   const [deleteModalOpened, { open: openDeleteModal, close: closeDeleteModal }] = useDisclosure(false);
+  const [multiDeleteModalOpened, { open: openMultiDeleteModal, close: closeMultiDeleteModal }] = useDisclosure(false);
+
+  const [activeBlockedVideos, setActiveBlockedVideos] = useState<BlockedVideo[] | null>([]);
+
   const axiosPrivate = useAxiosPrivate()
 
   const { data: blockedVideos, isPending, isError } = useGetBlockedVideos(axiosPrivate)
@@ -80,6 +85,24 @@ const AdminBlockedVideosPage = () => {
         <Group justify="space-between" mt={2} >
           <Title>Manage Blocked Videos</Title>
           <Box>
+            {(activeBlockedVideos && activeBlockedVideos.length >= 1) && (
+              <Button
+                mx={10}
+                leftSection={<IconTrash size={16} />}
+                color="red"
+                disabled={!activeBlockedVideos.length}
+                onClick={() => {
+                  openMultiDeleteModal();
+                }}
+              >
+                {activeBlockedVideos.length
+                  ? `Delete ${activeBlockedVideos.length === 1
+                    ? "one selected blocked video"
+                    : `${activeBlockedVideos.length} selected blocked videos`
+                  }`
+                  : "Select blocked videos to delete"}
+              </Button>
+            )}
             <Button
               onClick={() => {
                 setActiveBlockedVideo(null)
@@ -148,6 +171,8 @@ const AdminBlockedVideosPage = () => {
             onRecordsPerPageChange={setPerPage}
             sortStatus={sortStatus}
             onSortStatusChange={setSortStatus}
+            selectedRecords={activeBlockedVideos ?? []}
+            onSelectedRecordsChange={setActiveBlockedVideos}
           />
         </Box>
       </Container>
@@ -159,6 +184,12 @@ const AdminBlockedVideosPage = () => {
       <Modal opened={deleteModalOpened} onClose={closeDeleteModal} title="Delete Channel">
         {activeBlockedVideo && (
           <DeleteBlockedVideoModalContent blockedVideo={activeBlockedVideo} handleClose={closeDeleteModal} />
+        )}
+      </Modal>
+
+      <Modal opened={multiDeleteModalOpened} onClose={closeMultiDeleteModal} title="Delete Queue Items">
+        {activeBlockedVideos && (
+          <MultiDeleteBlockedVideoModalContent blockedVideos={activeBlockedVideos} handleClose={closeMultiDeleteModal} />
         )}
       </Modal>
 

--- a/frontend/app/admin/queue/page.tsx
+++ b/frontend/app/admin/queue/page.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { ActionIcon, Container, Group, TextInput, Title, Box, Drawer, Modal, Tooltip, Text } from "@mantine/core";
+import { ActionIcon, Container, Group, TextInput, Title, Box, Drawer, Modal, Tooltip, Text, Button } from "@mantine/core";
 import { useDebouncedValue, useDisclosure } from "@mantine/hooks";
 import { DataTable, DataTableSortStatus } from "mantine-datatable";
 import { useEffect, useState } from "react";
@@ -13,6 +13,7 @@ import { useAxiosPrivate } from "@/app/hooks/useAxios";
 import AdminQueueDrawerContent from "@/app/components/admin/queue/DrawerContent";
 import DeleteQueueModalContent from "@/app/components/admin/queue/DeleteModalContent";
 import Link from "next/link";
+import MultiDeleteQueueModalContent from "@/app/components/admin/queue/MultiDeleteModalContext";
 
 const AdminQueuePage = () => {
   useEffect(() => {
@@ -32,6 +33,9 @@ const AdminQueuePage = () => {
 
   const [queueDrawerOpened, { open: openQueueDrawer, close: closeQueueDrawer }] = useDisclosure(false);
   const [deleteModalOpened, { open: openDeleteModal, close: closeDeleteModal }] = useDisclosure(false);
+  const [multiDeleteModalOpened, { open: openMultiDeleteModal, close: closeMultiDeleteModal }] = useDisclosure(false);
+
+  const [activeQueueItems, setActiveQueueItems] = useState<Queue[] | null>([]);
 
   const axiosPrivate = useAxiosPrivate()
   const { data: queues, isPending, isError } = useGetQueueItems(axiosPrivate, false)
@@ -84,6 +88,26 @@ const AdminQueuePage = () => {
       <Container size="7xl">
         <Group justify="space-between" mt={2} >
           <Title>Manage Queue</Title>
+          <Box>
+            {(activeQueueItems && activeQueueItems.length >= 1) && (
+              <Button
+                mx={10}
+                leftSection={<IconTrash size={16} />}
+                color="red"
+                disabled={!activeQueueItems.length}
+                onClick={() => {
+                  openMultiDeleteModal();
+                }}
+              >
+                {activeQueueItems.length
+                  ? `Delete ${activeQueueItems.length === 1
+                    ? "one selected queue item"
+                    : `${activeQueueItems.length} selected queue items`
+                  }`
+                  : "Select queue items to delete"}
+              </Button>
+            )}
+          </Box>
         </Group>
 
         <Box mt={5}>
@@ -204,6 +228,8 @@ const AdminQueuePage = () => {
             onRecordsPerPageChange={setPerPage}
             sortStatus={sortStatus}
             onSortStatusChange={setSortStatus}
+            selectedRecords={activeQueueItems ?? []}
+            onSelectedRecordsChange={setActiveQueueItems}
           />
         </Box>
       </Container>
@@ -218,6 +244,12 @@ const AdminQueuePage = () => {
       <Modal opened={deleteModalOpened} onClose={closeDeleteModal} title="Delete Queue">
         {activeQueue && (
           <DeleteQueueModalContent queue={activeQueue} handleClose={closeDeleteModal} />
+        )}
+      </Modal>
+
+      <Modal opened={multiDeleteModalOpened} onClose={closeMultiDeleteModal} title="Delete Queue Items">
+        {activeQueueItems && (
+          <MultiDeleteQueueModalContent queues={activeQueueItems} handleClose={closeMultiDeleteModal} />
         )}
       </Modal>
 

--- a/frontend/app/admin/videos/page.tsx
+++ b/frontend/app/admin/videos/page.tsx
@@ -178,7 +178,12 @@ const AdminVideosPage = () => {
               },
               { accessor: "title", title: "Title", sortable: true, },
               { accessor: "type", title: "Type", sortable: true },
-
+              {
+                accessor: "locked", title: "Locked", sortable: true,
+                render: ({ locked }) => {
+                  return locked ? "✅" : "❌";
+                },
+              },
               {
                 accessor: "streamed_at",
                 title: "Streamed At",

--- a/frontend/app/admin/videos/page.tsx
+++ b/frontend/app/admin/videos/page.tsx
@@ -99,7 +99,7 @@ const AdminVideosPage = () => {
         <Group justify="space-between" mt={2} >
           <Title>Manage Videos</Title>
           <Box>
-            {(activeVideos && activeVideos.length > 1) && (
+            {(activeVideos && activeVideos.length >= 1) && (
               <Button
                 mx={10}
                 leftSection={<IconTrash size={16} />}

--- a/frontend/app/components/admin/blocked-videos/MultiDeleteModalContent.tsx
+++ b/frontend/app/components/admin/blocked-videos/MultiDeleteModalContent.tsx
@@ -1,0 +1,47 @@
+import { useAxiosPrivate } from "@/app/hooks/useAxios";
+import { BlockedVideo, useUnblockVideo } from "@/app/hooks/useBlockedVideos";
+import { Button, Text } from "@mantine/core";
+import { showNotification } from "@mantine/notifications";
+import { useState } from "react";
+
+type Props = {
+  blockedVideos: BlockedVideo[]
+  handleClose: () => void;
+}
+
+const MultiDeleteBlockedVideoModalContent = ({ blockedVideos, handleClose }: Props) => {
+  const [loading, setLoading] = useState(false)
+  const unblockVideoMutate = useUnblockVideo()
+  const axiosPrivate = useAxiosPrivate()
+
+  const handleDeleteQueue = async () => {
+    setLoading(true)
+    try {
+      await Promise.all(blockedVideos.map(async (blockedVideo) => {
+
+        await unblockVideoMutate.mutateAsync({
+          axiosPrivate: axiosPrivate,
+          videoId: blockedVideo.id,
+        })
+      }))
+
+      showNotification({
+        message: "Unblocked videos deleted"
+      })
+      handleClose()
+    } catch (error) {
+      console.error(error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <Text>Are you sure you want to unblock the {blockedVideos.length} selected blocked videos?</Text>
+      <Button mt={5} color="red" onClick={handleDeleteQueue} loading={loading} fullWidth>Unblock Videos</Button>
+    </div>
+  );
+}
+
+export default MultiDeleteBlockedVideoModalContent;

--- a/frontend/app/components/admin/queue/MultiDeleteModalContext.tsx
+++ b/frontend/app/components/admin/queue/MultiDeleteModalContext.tsx
@@ -1,0 +1,47 @@
+import { useAxiosPrivate } from "@/app/hooks/useAxios";
+import { Queue, useDeleteQueue } from "@/app/hooks/useQueue";
+import { Button, Text } from "@mantine/core";
+import { showNotification } from "@mantine/notifications";
+import { useState } from "react";
+
+type Props = {
+  queues: Queue[]
+  handleClose: () => void;
+}
+
+const MultiDeleteQueueModalContent = ({ queues, handleClose }: Props) => {
+  const [loading, setLoading] = useState(false)
+  const deleteQueueMutate = useDeleteQueue()
+  const axiosPrivate = useAxiosPrivate()
+
+  const handleDeleteQueue = async () => {
+    setLoading(true)
+    try {
+      await Promise.all(queues.map(async (queue) => {
+
+        await deleteQueueMutate.mutateAsync({
+          axiosPrivate: axiosPrivate,
+          queueId: queue.id,
+        })
+      }))
+
+      showNotification({
+        message: "Queues deleted"
+      })
+      handleClose()
+    } catch (error) {
+      console.error(error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <Text>Are you sure you want to delete the {queues.length} selected queue items?</Text>
+      <Button mt={5} color="red" onClick={handleDeleteQueue} loading={loading} fullWidth>Delete Queue Items</Button>
+    </div>
+  );
+}
+
+export default MultiDeleteQueueModalContent;

--- a/frontend/app/components/videos/Card.tsx
+++ b/frontend/app/components/videos/Card.tsx
@@ -11,7 +11,7 @@ import { escapeURL } from "@/app/util/util";
 import { PlaybackStatus, useFetchPlaybackForVideo } from "@/app/hooks/usePlayback";
 import { useAxiosPrivate } from "@/app/hooks/useAxios";
 import useAuthStore from "@/app/store/useAuthStore";
-import { IconCircleCheck } from "@tabler/icons-react";
+import { IconCircleCheck, IconLock } from "@tabler/icons-react";
 import VideoMenu from "./Menu";
 import { UserRole } from "@/app/hooks/useAuthentication";
 
@@ -106,14 +106,34 @@ const VideoCard = ({ video, showProgress = true, showMenu = true, showChannel = 
         </Text>
       </Badge>
 
-      {/* Watched icon */}
-      {showProgress && playbackIsWatched && (
-        <Tooltip label="You have watched this video">
-          <ThemeIcon className={classes.watchedIcon} radius="xl" color="green">
-            <IconCircleCheck />
-          </ThemeIcon>
-        </Tooltip>
-      )}
+      <Flex
+        gap="xs"
+        justify="flex-start"
+        align="flex-start"
+        direction="column"
+        wrap="wrap"
+        className={classes.watchedIcon}
+      >
+        {/* Watched icon */}
+        {showProgress && playbackIsWatched && (
+          <Tooltip label="You have watched this video">
+            <ThemeIcon radius="xl" color="green">
+              <IconCircleCheck />
+            </ThemeIcon>
+          </Tooltip>
+        )}
+
+        {/* Locked icon */}
+        {video.locked && (
+          <Tooltip label="Video is locked">
+            <ThemeIcon radius="xl" color="gray">
+              <IconLock />
+            </ThemeIcon>
+          </Tooltip>
+        )}
+      </Flex>
+
+
 
       {/* Title */}
       <Link href={video.processing ? `#` : `/videos/${video.id}`}>

--- a/frontend/app/components/videos/ChannelVideos.tsx
+++ b/frontend/app/components/videos/ChannelVideos.tsx
@@ -36,6 +36,7 @@ const ChannelVideos = ({ channel }: Props) => {
     <div>
       <VideoGrid
         videos={videos.data}
+        totalCount={videos.total_count}
         totalPages={videos.pages}
         currentPage={activePage}
         onPageChange={setActivePage}

--- a/frontend/app/components/videos/Grid.tsx
+++ b/frontend/app/components/videos/Grid.tsx
@@ -1,4 +1,3 @@
-// VideoGrid.tsx
 import { Box, Center, Group, Pagination, SimpleGrid, ActionIcon, NumberInput, MultiSelect, Text } from "@mantine/core";
 import { IconMinus, IconPlus } from "@tabler/icons-react";
 import { useRef, useState, useEffect } from "react";
@@ -9,6 +8,7 @@ import GanymedeLoadingText from "../utils/GanymedeLoadingText";
 
 export type VideoGridProps<T extends Video> = {
   videos: T[];
+  totalCount: number;
   totalPages: number;
   currentPage: number;
   onPageChange: (page: number) => void;
@@ -23,6 +23,7 @@ export type VideoGridProps<T extends Video> = {
 
 const VideoGrid = <T extends Video>({
   videos,
+  totalCount,
   totalPages,
   currentPage,
   onPageChange,
@@ -37,7 +38,6 @@ const VideoGrid = <T extends Video>({
   const handlersRef = useRef<NumberInputHandlers>(null);
   // Local state to handle the input value while typing
   const [localLimit, setLocalLimit] = useState(videoLimit);
-  const [totalVideoCount, setTotalVideoCount] = useState(0);
   const [videoTypes, setVideoTypes] = useState<VideoType[]>([]);
 
   useEffect(() => {
@@ -54,11 +54,6 @@ const VideoGrid = <T extends Video>({
       onVideoLimitChange(numValue);
     }
   };
-
-  useEffect(() => {
-    if (!videos) return;
-    setTotalVideoCount(videos.length);
-  }, [videos]);
 
   // Convert the enum VideoType to an array for the multiselector
   const selectorVideoTypes = Object.values(VideoType).map((type) => ({
@@ -110,7 +105,7 @@ const VideoGrid = <T extends Video>({
           />
         </Box>
         <div>
-          <Text>{totalVideoCount.toLocaleString()} Videos</Text>
+          <Text>{totalCount.toLocaleString()} Videos</Text>
         </div>
       </Group>
 

--- a/frontend/app/components/videos/TitleBar.tsx
+++ b/frontend/app/components/videos/TitleBar.tsx
@@ -1,10 +1,10 @@
 "use client"
 import { useGetVideoByExternalId, Video } from "@/app/hooks/useVideos";
 import { escapeURL } from "@/app/util/util";
-import { Avatar, Box, Divider, Tooltip, Text, Group, Badge, Button } from "@mantine/core";
+import { Avatar, Box, Divider, Tooltip, Text, Group, Badge, Button, rem } from "@mantine/core";
 import { env } from "next-runtime-env";
 import classes from "./TitleBar.module.css";
-import { IconCalendarEvent, IconUser, IconUsers } from "@tabler/icons-react";
+import { IconCalendarEvent, IconLock, IconUser, IconUsers } from "@tabler/icons-react";
 import dayjs from "dayjs";
 import VideoMenu from "./Menu";
 import useAuthStore from "@/app/store/useAuthStore";
@@ -91,6 +91,18 @@ const VideoTitleBar = ({ video }: Params) => {
                 </div>
               </Tooltip>
             </Group>
+
+            {video.locked && (
+              <Group mr={5}>
+                <Tooltip label={`Video is locked`} openDelay={250}>
+                  <div className={classes.titleBarBadge}>
+                    <Badge variant="default" leftSection={<IconLock style={{ width: rem(12), height: rem(12) }} />}>
+                      Locked
+                    </Badge>
+                  </div>
+                </Tooltip>
+              </Group>
+            )}
 
             <Group>
               <Tooltip label={`Video Type`} openDelay={250}>

--- a/frontend/app/hooks/useVideos.ts
+++ b/frontend/app/hooks/useVideos.ts
@@ -406,7 +406,8 @@ const useLockVideo = () => {
     mutationFn: ({ axiosPrivate, videoId, locked }) =>
       lockVideo(axiosPrivate, videoId, locked),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["video"] });
+      // @ts-expect-error fine
+      queryClient.invalidateQueries(["channel_videos"]);
     },
   });
 };

--- a/frontend/app/playlists/[id]/page.tsx
+++ b/frontend/app/playlists/[id]/page.tsx
@@ -67,6 +67,7 @@ const PlaylistPage = ({ params }: { params: Promise<Params> }) => {
       </Center>
       <VideoGrid
         videos={videos.data}
+        totalCount={videos.total_count}
         totalPages={videos.pages}
         currentPage={activePage}
         onPageChange={setActivePage}

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -60,6 +60,7 @@ const SearchPage = () => {
       <Container size="xl" px="xl" fluid={true}>
         <VideoGrid
           videos={videos.data}
+          totalCount={videos.total_count}
           totalPages={videos.pages}
           currentPage={activePage}
           onPageChange={setActivePage}


### PR DESCRIPTION
- Add indicators for locked videos.
  - ![image](https://github.com/user-attachments/assets/6e2e8c9a-d9e9-4129-93d1-22c2e4cdd30c)
  - ![image](https://github.com/user-attachments/assets/77dc8b38-1f77-452b-a0d2-d542b9afcb4d)
- Add multi select delete for queues and blocked videos.
- Fix the "`N` Videos" in the top right of the video grid.