### PR TITLE
fix(frontend): make env vars available in browser

### DIFF
--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -131,7 +131,7 @@ const AdminSettingsPage = () => {
             handleSubmitForm()
           })}>
             <Title>Settings</Title>
-            <Text>Visit the <a href="https://github.com/Zibbp/ganymede/wiki/Application-Settings" target="_blank">wiki</a> for documentation about each setting.</Text>
+            <Text>Visit the <a className={classes.link} href="https://github.com/Zibbp/ganymede/wiki/Application-Settings" target="_blank">wiki</a> for documentation about each setting.</Text>
 
             <Title order={3}>Application</Title>
             <Checkbox

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -27,7 +27,11 @@ export default function RootLayout({
         <PublicEnvScript />
         <EnvScript
           env={{
-            NEXT_PUBLIC_SHOW_SSO_LOGIN_BUTTON: process.env.SHOW_SSO_LOGIN_BUTTON
+            NEXT_PUBLIC_SHOW_SSO_LOGIN_BUTTON: process.env.SHOW_SSO_LOGIN_BUTTON,
+            NEXT_PUBLIC_FORCE_SSO_AUTH: process.env.FORCE_SSO_AUTH,
+            NEXT_PUBLIC_REQUIRE_LOGIN: process.env.REQUIRE_LOGIN,
+            NEXT_PUBLIC_API_URL: process.env.API_URL,
+            NEXT_PUBLIC_CDN_URL: process.env.CDN_URL,
           }}
         />
         <ColorSchemeScript defaultColorScheme='dark' />

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -8,7 +8,7 @@ import '@/app/global.css'
 import { ColorSchemeScript } from '@mantine/core';
 import type { Metadata } from "next";
 import Providers from './providers';
-import { PublicEnvScript } from 'next-runtime-env';
+import { EnvScript, PublicEnvScript } from 'next-runtime-env';
 
 export const metadata: Metadata = {
   title: "Ganymede",
@@ -25,6 +25,11 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         <PublicEnvScript />
+        <EnvScript
+          env={{
+            NEXT_PUBLIC_SHOW_SSO_LOGIN_BUTTON: process.env.SHOW_SSO_LOGIN_BUTTON
+          }}
+        />
         <ColorSchemeScript defaultColorScheme='dark' />
       </head>
       <body>


### PR DESCRIPTION
This fixes a bug where environment variables were not properly being passed to the browser so the client-side javascript can use them.