### PR TITLE
feat(platform/twitch): log warning if ratelimit exceeds threshold

### DIFF
--- a/internal/platform/twitch_api.go
+++ b/internal/platform/twitch_api.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"github.com/zibbp/ganymede/internal/chapter"
 )
 
@@ -238,6 +240,41 @@ func (c *TwitchConnection) twitchMakeHTTPRequest(method, url string, queryParams
 			return nil, fmt.Errorf("failed to make request: %v", err)
 		}
 		defer resp.Body.Close()
+
+		// Log rate limit usage if over threshold
+		rateLimit := 0
+		rateLimitRemaining := 0
+		rateLimitReset := time.Time{}
+
+		if rateLimitStr := resp.Header.Get("Ratelimit-Limit"); rateLimitStr != "" {
+			if value, err := strconv.Atoi(rateLimitStr); err == nil {
+				rateLimit = value
+			} else {
+				fmt.Printf("Error parsing Ratelimit-Limit: %v\n", err)
+			}
+		}
+		if rateLimitRemainingStr := resp.Header.Get("Ratelimit-Remaining"); rateLimitRemainingStr != "" {
+			if value, err := strconv.Atoi(rateLimitRemainingStr); err == nil {
+				rateLimitRemaining = value
+			} else {
+				fmt.Printf("Error parsing Ratelimit-Remaining: %v\n", err)
+			}
+		}
+		if resp.Header.Get("Ratelimit-Reset") != "" {
+			unixTimeInt, err := strconv.ParseInt(resp.Header.Get("Ratelimit-Reset"), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse ratelimit reset time: %v", err)
+			}
+			unixTime := time.Unix(unixTimeInt, 0)
+			rateLimitReset = unixTime
+		}
+
+		if rateLimit > 0 && rateLimitRemaining > 0 {
+			usagePercentage := float64(rateLimit-rateLimitRemaining) / float64(rateLimit) * 100
+			if usagePercentage > 75 {
+				log.Warn().Int("rate_limit", rateLimit).Int("rate_limit_remaining", rateLimitRemaining).Str("rate_limit_expires", rateLimitReset.String()).Msgf("twitch rate limit usage is over 75%% - %d/%d remaining", rateLimitRemaining, rateLimit)
+			}
+		}
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
```
9:34PM WRN Rate limit usage is over 75% - 15/800 remaining rate_limit=800 rate_limit_expires="2025-01-22 21:34:43 -0600 CST" rate_limit_remaining=15
```

In my tests the rate limit never got below 799/800. From what I can tell Twitch is very generous with API limits.