### PR TITLE
feat(frontend): add settings to display processing video in recently archived

### DIFF
--- a/frontend/app/components/landing/RecentlyArchived.tsx
+++ b/frontend/app/components/landing/RecentlyArchived.tsx
@@ -3,6 +3,7 @@ import { useMediaQuery } from "@mantine/hooks"
 import VideoCard from "../videos/Card"
 import { Carousel } from "@mantine/carousel";
 import { useFetchVideosFilter } from "@/app/hooks/useVideos"
+import useSettingsStore from "@/app/store/useSettingsStore";
 
 type Props = {
   count: number
@@ -12,7 +13,9 @@ const RecentlyArchived = ({ count }: Props) => {
   const theme = useMantineTheme()
   const isMobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`);
 
-  const { data, isPending, isError } = useFetchVideosFilter({ limit: count, offset: 0, is_processing: false })
+  const showProcessingVideosInRecentlyArchived = useSettingsStore((state) => state.showProcessingVideosInRecentlyArchived);
+
+  const { data, isPending, isError } = useFetchVideosFilter({ limit: count, offset: 0, is_processing: showProcessingVideosInRecentlyArchived })
 
   if (isPending) return (<div></div>)
   if (isError) return <div>Error loading recently archived videos</div>

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -20,7 +20,9 @@ const ProfilePage = () => {
     chatPlaybackSmoothScroll,
     setChatPlaybackSmoothScroll,
     showChatHistogram,
-    setShowChatHistogram
+    setShowChatHistogram,
+    showProcessingVideosInRecentlyArchived,
+    setShowProcessingVideosInRecentlyArchived
   } = useSettingsStore();
 
   const toggleSmoothScroll = () => {
@@ -29,6 +31,10 @@ const ProfilePage = () => {
 
   const toggleChatHistogram = () => {
     setShowChatHistogram(!showChatHistogram);
+  }
+
+  const toggleProcessingVideosInRecentlyArchived = () => {
+    setShowProcessingVideosInRecentlyArchived(!showProcessingVideosInRecentlyArchived);
   }
 
   useEffect(() => {
@@ -60,12 +66,21 @@ const ProfilePage = () => {
                 description="Enable smooth scrolling for new chat messages. May look bad if there is a large volume of messages per second."
                 checked={chatPlaybackSmoothScroll}
                 onChange={toggleSmoothScroll}
+                my={5}
               />
               <Checkbox
                 label="Show Chat Histogram"
                 description="Display a visual representation of chat message throughout the video below the video player."
                 checked={showChatHistogram}
                 onChange={toggleChatHistogram}
+                my={5}
+              />
+              <Checkbox
+                label="Show Processing Videos in Recently Archived Videos"
+                description="Display processing videos in the 'Recently Archived' videos section on the home page."
+                checked={showProcessingVideosInRecentlyArchived}
+                onChange={toggleProcessingVideosInRecentlyArchived}
+                my={5}
               />
             </Box>
 

--- a/frontend/app/store/useSettingsStore.ts
+++ b/frontend/app/store/useSettingsStore.ts
@@ -6,10 +6,12 @@ interface SettingsState {
   chatPlaybackSmoothScroll: boolean;
   videoTheaterMode: boolean;
   showChatHistogram: boolean;
+  showProcessingVideosInRecentlyArchived: boolean;
   setVideoLimit: (limit: number) => void;
   setChatPlaybackSmoothScroll: (smooth: boolean) => void;
   setVideoTheaterMode: (theaterMode: boolean) => void;
   setShowChatHistogram: (show: boolean) => void;
+  setShowProcessingVideosInRecentlyArchived: (show: boolean) => void;
 }
 
 // Create the store with persist middleware
@@ -21,6 +23,7 @@ const useSettingsStore = create<SettingsState>()(
       chatPlaybackSmoothScroll: false,
       videoTheaterMode: false,
       showChatHistogram: true,
+      showProcessingVideosInRecentlyArchived: true,
 
       setVideoLimit: (limit: number) => set({ videoLimit: limit }),
 
@@ -31,6 +34,9 @@ const useSettingsStore = create<SettingsState>()(
         set({ videoTheaterMode: theaterMode }),
 
       setShowChatHistogram: (show: boolean) => set({ showChatHistogram: show }),
+
+      setShowProcessingVideosInRecentlyArchived: (show: boolean) =>
+        set({ showProcessingVideosInRecentlyArchived: show }),
     }),
     {
       name: "settings-storage",
@@ -38,6 +44,8 @@ const useSettingsStore = create<SettingsState>()(
         videoLimit: state.videoLimit,
         chatPlaybackSmoothScroll: state.chatPlaybackSmoothScroll,
         showChatHistogram: state.showChatHistogram,
+        showProcessingVideosInRecentlyArchived:
+          state.showProcessingVideosInRecentlyArchived,
       }),
     }
   )


### PR DESCRIPTION
Instead of hard coding it in https://github.com/Zibbp/ganymede/pull/606 add a setting to allow users to toggle this in their profile settings.
Original issue - https://github.com/Zibbp/ganymede/issues/598