### PR TITLE
fix(frontend/chatplayer): track processed chat ids to prevent duplicates

### DIFF
--- a/frontend/app/components/videos/ChatMessage.tsx
+++ b/frontend/app/components/videos/ChatMessage.tsx
@@ -15,14 +15,16 @@ const ChatMessage = ({ comment }: Params) => {
         {comment.ganymede_formatted_badges &&
           comment.ganymede_formatted_badges.map(
             (badge: GanymedeFormattedBadge) => (
-              <Tooltip key={badge._id} label={badge.title} position="top">
-                <img
-                  className={classes.badge}
-                  src={badge.url}
-                  height="18"
-                  alt={badge.title}
-                />
-              </Tooltip>
+              badge.url && (
+                <Tooltip key={badge._id} label={badge.title} position="top">
+                  <img
+                    className={classes.badge}
+                    src={badge.url}
+                    height="18"
+                    alt={badge.title}
+                  />
+                </Tooltip>
+              )
             )
           )}
       </span>

--- a/frontend/app/components/videos/ChatPlayer.tsx
+++ b/frontend/app/components/videos/ChatPlayer.tsx
@@ -389,6 +389,9 @@ const ChatPlayer = ({ video }: Params) => {
         clearChat();
         lastEndTimeRef.current = 0;
         lastCheckTimeRef.current = time;
+        // clear processed IDs to prevent duplicates
+        processedIds.clear();
+        processedIdsOrder.length = 0;
         getSeekChat(time, 50);
       }
 


### PR DESCRIPTION
Fixes the edge case in #669 where a comment's offset is a whole number which may get processed multiple times if the start/end times of fetching the next batch of comments aligns with the comment's offset. Comment IDs are kept in a variable and checked before appending to the chat.