### PR TITLE
feat: select closest quality when archiving

### DIFF
--- a/frontend/app/hooks/useArchive.ts
+++ b/frontend/app/hooks/useArchive.ts
@@ -14,10 +14,11 @@ export interface ArchiveVideoInput {
 
 export enum VideoQuality {
   Best = "best",
-  quality720p60 = "720p60",
-  quality480p = "480p30",
-  quality360p = "360p30",
-  quality160p = "160p30",
+  quality1080p = "1080p",
+  quality720p = "720p",
+  quality480p = "480p",
+  quality360p = "360p",
+  quality160p = "160p",
   audio = "audio",
 }
 

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -67,7 +67,7 @@ func TestArchiveVideo(t *testing.T) {
 	// Archive the video
 	err = app.ArchiveService.ArchiveVideo(context.Background(), archive.ArchiveVideoInput{
 		VideoId:     TestTwitchVideoId,
-		Quality:     utils.R720P60,
+		Quality:     utils.R720,
 		ArchiveChat: true,
 		RenderChat:  true,
 	})
@@ -145,7 +145,7 @@ func TestArchiveVideoNoChat(t *testing.T) {
 	// Archive the video
 	err = app.ArchiveService.ArchiveVideo(context.Background(), archive.ArchiveVideoInput{
 		VideoId:     TestTwitchVideoId,
-		Quality:     utils.R720P60,
+		Quality:     utils.R720,
 		ArchiveChat: false,
 		RenderChat:  false,
 	})
@@ -223,7 +223,7 @@ func TestArchiveVideoNoChatRender(t *testing.T) {
 	// Archive the video
 	err = app.ArchiveService.ArchiveVideo(context.Background(), archive.ArchiveVideoInput{
 		VideoId:     TestTwitchVideoId,
-		Quality:     utils.R720P60,
+		Quality:     utils.R720,
 		ArchiveChat: true,
 		RenderChat:  false,
 	})
@@ -306,7 +306,7 @@ func TestArchiveVideoHLS(t *testing.T) {
 	// Archive the video
 	err = app.ArchiveService.ArchiveVideo(context.Background(), archive.ArchiveVideoInput{
 		VideoId:     TestTwitchVideoId,
-		Quality:     utils.R720P60,
+		Quality:     utils.R720,
 		ArchiveChat: false,
 		RenderChat:  false,
 	})
@@ -392,7 +392,7 @@ func TestArchiveClip(t *testing.T) {
 	// Archive the video
 	err = app.ArchiveService.ArchiveClip(context.Background(), archive.ArchiveClipInput{
 		ID:          TestTwitchClipId,
-		Quality:     utils.R720P60,
+		Quality:     utils.R720,
 		ArchiveChat: true,
 		RenderChat:  true,
 	})
@@ -470,7 +470,7 @@ func TestArchiveVideoWithSpriteThumbnails(t *testing.T) {
 	// Archive the video
 	err = app.ArchiveService.ArchiveVideo(context.Background(), archive.ArchiveVideoInput{
 		VideoId:     TestTwitchVideoId,
-		Quality:     utils.R720P60,
+		Quality:     utils.R720,
 		ArchiveChat: false,
 		RenderChat:  false,
 	})

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -43,8 +43,20 @@ func DownloadTwitchVideo(ctx context.Context, video ent.Vod) error {
 		videoURL = fmt.Sprintf("https://twitch.tv/%s/clip/%s", channel.DisplayName, video.ExtID)
 	}
 
+	// If not best or audio, get the closest quality for the video
+	closestQuality := video.Resolution
+	if closestQuality != "best" && closestQuality != "audio" {
+		qualities, err := GetTwitchVideoQualityOptions(ctx, video)
+		if err != nil {
+			return fmt.Errorf("error getting video quality options: %w", err)
+		}
+		closestQuality = utils.SelectClosestQuality(video.Resolution, qualities) // Use '=' instead of ':='
+
+		log.Info().Msgf("selected closest quality %s", closestQuality)
+	}
+
 	var cmdArgs []string
-	cmdArgs = append(cmdArgs, videoURL, fmt.Sprintf("%s,best", video.Resolution), "--progress=force", "--force")
+	cmdArgs = append(cmdArgs, videoURL, fmt.Sprintf("%s,best", closestQuality), "--progress=force", "--force")
 
 	// check if user has twitch token set
 	// if so, set token in streamlink command
@@ -93,6 +105,51 @@ func DownloadTwitchVideo(ctx context.Context, video ent.Vod) error {
 	}
 
 	return nil
+}
+
+// GetTwitchVideoQualityOptions returns a list of available quality options for a Twitch video.
+func GetTwitchVideoQualityOptions(ctx context.Context, video ent.Vod) ([]string, error) {
+	// Get channel for video
+	vC := video.QueryChannel()
+	channel, err := vC.Only(ctx)
+	if err != nil {
+		return nil, err
+	}
+	video.Edges.Channel = channel
+	// Get video URL based on video type
+	var url string
+	switch video.Type {
+	case utils.Clip:
+		url = fmt.Sprintf("https://twitch.tv/%s/clip/%s", video.Edges.Channel.Name, video.ExtID)
+	case utils.Live:
+		url = fmt.Sprintf("https://twitch.tv/%s", video.Edges.Channel.Name)
+	default:
+		url = fmt.Sprintf("https://twitch.tv/videos/%s", video.ExtID)
+	}
+	args := []string{"--json", url}
+	cmd := osExec.CommandContext(ctx, "streamlink", args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		log.Error().Err(err).Str("stderr", stderr.String()).Str("stdout", stdout.String()).Msg("error running streamlink")
+		return nil, fmt.Errorf("error running streamlink: %w", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &data); err != nil {
+		log.Error().Err(err).Msg("error unmarshalling streamlink data")
+		return nil, err
+	}
+
+	qualities := make([]string, 0)
+	for key := range data["streams"].(map[string]interface{}) {
+		qualities = append(qualities, key)
+	}
+
+	return qualities, nil
 }
 
 func DownloadTwitchLiveVideo(ctx context.Context, video ent.Vod, channel ent.Channel, startChat chan bool) error {
@@ -153,16 +210,25 @@ func DownloadTwitchLiveVideo(ctx context.Context, video ent.Vod, channel ent.Cha
 		}
 	}
 
-	// streamlink livestreams do not use the 30 fps suffix
-	video.Resolution = strings.Replace(video.Resolution, "30", "", 1)
+	// If not best or audio, get the closest quality for the video
+	closestQuality := video.Resolution
+	if closestQuality != "best" && closestQuality != "audio" {
+		qualities, err := GetTwitchVideoQualityOptions(ctx, video)
+		if err != nil {
+			return fmt.Errorf("error getting video quality options: %w", err)
+		}
+		closestQuality = utils.SelectClosestQuality(video.Resolution, qualities) // Use '=' instead of ':='
+
+		log.Info().Msgf("selected closest quality %s", closestQuality)
+	}
 
 	// streamlink livestreams expect 'audio_only' instead of 'audio'
-	if video.Resolution == "audio" {
-		video.Resolution = "audio_only"
+	if closestQuality == "audio" {
+		closestQuality = "audio_only"
 	}
 
 	var cmdArgs []string
-	cmdArgs = append(cmdArgs, streamUrl, fmt.Sprintf("%s,best", video.Resolution), "--progress=force", "--force")
+	cmdArgs = append(cmdArgs, streamUrl, fmt.Sprintf("%s,best", closestQuality), "--progress=force", "--force")
 
 	// pass proxy header
 	if proxyHeader != "" {

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -1,1 +1,57 @@
-package exec_test
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zibbp/ganymede/ent"
+	"github.com/zibbp/ganymede/internal/utils"
+)
+
+// TestGetTwitchVideoQualityOptions tests the GetTwitchVideoQualityOptions function
+func TestGetTwitchVideoQualityOptions(t *testing.T) {
+	testCases := []struct {
+		videoId     string
+		expectedLen int
+		description string
+		videoType   utils.VodType
+		channelName string
+	}{
+		{
+			videoId:     "2325332129",
+			expectedLen: 9,
+			description: "Standard archive VOD",
+			videoType:   utils.Archive,
+			channelName: "datmodz",
+		},
+		{
+			videoId:     "CleverPolishedSwordPanicBasket-qmNOWICct4rtR_wX",
+			expectedLen: 6,
+			description: "Clip",
+			videoType:   utils.Clip,
+			channelName: "datmodz",
+		}}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			// Setup VOD object
+			v := ent.Vod{
+				ExtID: tc.videoId,
+				Type:  tc.videoType,
+			}
+			c := ent.Channel{}
+			v.Edges.Channel = &c
+			v.Edges.Channel.Name = tc.channelName
+
+			qualities, err := GetTwitchVideoQualityOptions(context.Background(), v)
+			assert.NoError(t, err)
+
+			t.Logf("Qualities for VOD %s: %v", tc.videoId, qualities)
+
+			assert.Equal(t, tc.expectedLen, len(qualities),
+				"Expected %d quality options for VOD %s, got %d",
+				tc.expectedLen, tc.videoId, len(qualities))
+		})
+	}
+}

--- a/internal/transport/http/archive.go
+++ b/internal/transport/http/archive.go
@@ -29,7 +29,7 @@ type ArchiveChannelRequest struct {
 type ArchiveVideoRequest struct {
 	VideoId     string           `json:"video_id"`
 	ChannelId   string           `json:"channel_id"`
-	Quality     utils.VodQuality `json:"quality" validate:"required,oneof=best source 720p60 480p30 360p30 160p30 480p 360p 160p audio"`
+	Quality     utils.VodQuality `json:"quality" validate:"required,oneof=best 1080p 720p 480p 360p 160p audio"`
 	ArchiveChat bool             `json:"archive_chat"`
 	RenderChat  bool             `json:"render_chat"`
 }

--- a/internal/utils/enum.go
+++ b/internal/utils/enum.go
@@ -79,16 +79,18 @@ func (TaskStatus) Values() (kinds []string) {
 type VodQuality string
 
 const (
-	Best    VodQuality = "best"
-	Source  VodQuality = "source"
-	R720P60 VodQuality = "720p60"
-	R480P30 VodQuality = "480p30"
-	R360P30 VodQuality = "360p30"
-	R160P30 VodQuality = "160p30"
+	Best   VodQuality = "best"
+	Source VodQuality = "source"
+	R1080  VodQuality = "1080"
+	R720   VodQuality = "720"
+	R480   VodQuality = "480"
+	R360   VodQuality = "360"
+	R160   VodQuality = "160"
+	Audio  VodQuality = "audio"
 )
 
 func (VodQuality) Values() (kinds []string) {
-	for _, s := range []VodQuality{Best, Source, R720P60, R480P30, R360P30, R160P30} {
+	for _, s := range []VodQuality{Best, Source, R1080, R720, R480, R360, R160, Audio} {
 		kinds = append(kinds, string(s))
 	}
 	return

--- a/internal/utils/video.go
+++ b/internal/utils/video.go
@@ -1,0 +1,89 @@
+package utils
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"unicode"
+)
+
+// Quality represents a video quality option with resolution, FPS, and original string representation.
+type Quality struct {
+	Resolution int
+	FPS        int
+	Original   string
+}
+
+// parseQuality extracts resolution and FPS from a quality string (e.g., "1080p60").
+// If no FPS is provided, it defaults to 60.
+func parseQuality(q string) Quality {
+	re := regexp.MustCompile(`(\d+)p(\d+)?`)
+	matches := re.FindStringSubmatch(q)
+	if len(matches) == 0 {
+		return Quality{Original: q}
+	}
+	res, _ := strconv.Atoi(matches[1])
+	fps := 0
+	if len(matches) > 2 && matches[2] != "" {
+		fps, _ = strconv.Atoi(matches[2])
+	}
+	return Quality{Resolution: res, FPS: fps, Original: q}
+}
+
+// SelectClosestQuality selects the best matching quality from available options.
+// Streams and video can vary quite a bit in quality, so it's important to select the closest match.
+// If an exact match is found, it returns that.
+// If an exact FPS match isn't found, it selects the closest lower FPS.
+// If no matching resolution is found, it falls back to "best".
+// If the target is a non-numeric string, it returns the input directly.
+func SelectClosestQuality(target string, options []string) string {
+	if len(target) == 0 || !unicode.IsDigit(rune(target[0])) {
+		return target // Return if non-numeric string
+	}
+
+	targetQuality := parseQuality(target)
+
+	// Parse all options
+	var parsedOptions []Quality
+	for _, opt := range options {
+		parsedOptions = append(parsedOptions, parseQuality(opt))
+	}
+
+	// Filter options that match the target resolution
+	var matchingRes []Quality
+	for _, opt := range parsedOptions {
+		if opt.Resolution == targetQuality.Resolution {
+			matchingRes = append(matchingRes, opt)
+		}
+	}
+
+	if len(matchingRes) == 0 {
+		return "best" // Fallback if no resolution matches
+	}
+
+	// If target specifies FPS (e.g., "720p60")
+	if regexp.MustCompile(`\d+p\d+`).MatchString(target) {
+		// Look for an exact FPS match
+		for _, opt := range matchingRes {
+			if opt.FPS == targetQuality.FPS {
+				return opt.Original
+			}
+		}
+		// No exact match, find closest lower FPS or lowest if all higher
+		sort.Slice(matchingRes, func(i, j int) bool {
+			return matchingRes[i].FPS > matchingRes[j].FPS
+		})
+		for _, opt := range matchingRes {
+			if opt.FPS <= targetQuality.FPS {
+				return opt.Original
+			}
+		}
+		return matchingRes[len(matchingRes)-1].Original // Lowest FPS if all higher
+	} else {
+		// Target has no FPS (e.g., "720p"), pick highest FPS available
+		sort.Slice(matchingRes, func(i, j int) bool {
+			return matchingRes[i].FPS > matchingRes[j].FPS
+		})
+		return matchingRes[0].Original // Highest FPS option
+	}
+}

--- a/internal/utils/video_test.go
+++ b/internal/utils/video_test.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestSelectClosestQuality validates the logic for selecting the closest quality.
+func TestSelectClosestQuality(t *testing.T) {
+	tests := []struct {
+		target   string
+		options  []string
+		expected string
+	}{
+		{"1080p60", []string{"audio", "160p", "360p", "720p", "1080p60", "480p", "720p60", "worst", "best", "audio_only"}, "1080p60"},
+		{"1080p", []string{"audio", "160p", "360p", "720p", "1080p30", "480p", "720p60", "worst", "best", "audio_only"}, "1080p30"},
+		{"1080p", []string{"audio", "160p", "360p", "720p", "1080p", "480p", "720p60", "worst", "best", "audio_only"}, "1080p"},
+		{"1080p30", []string{"audio", "160p", "360p", "720p", "1080p30", "1080p60", "480p", "720p60", "worst", "best", "audio_only"}, "1080p30"},
+		{"1080p", []string{"audio", "160p", "360p", "720p", "1080p30", "1080p60", "480p", "720p60", "worst", "best", "audio_only"}, "1080p60"},
+		{"1080p", []string{"audio", "160p", "360p", "720p", "1080p", "480p", "720p60", "worst", "best", "audio_only"}, "1080p"},
+		{"720p", []string{"audio", "160p", "360p", "720p", "1080p60", "480p", "720p60", "worst", "best", "audio_only"}, "720p60"},
+		{"720p30", []string{"audio", "160p", "360p", "720p", "1080p60", "480p", "720p60", "worst", "best", "audio_only"}, "720p"},
+		{"480p", []string{"audio", "160p", "360p", "720p", "1080p60", "480p", "720p60", "worst", "best", "audio_only"}, "480p"},
+		{"480p", []string{"audio", "160p", "360p", "720p", "1080p60", "480p30", "720p60", "worst", "best", "audio_only"}, "480p30"},
+		{"480p30", []string{"audio", "160p", "360p", "720p", "1080p60", "480p", "720p60", "worst", "best", "audio_only"}, "480p"},
+		{"240p", []string{"audio", "160p", "360p", "720p", "1080p60", "480p", "720p60", "worst", "best", "audio_only"}, "best"},
+		{"best", []string{"audio", "160p", "360p", "720p", "1080p60", "480p", "720p60", "worst", "best", "audio_only"}, "best"},
+		{"audio_only", []string{"audio", "160p", "360p", "720p", "1080p60", "480p", "720p60", "worst", "best", "audio_only"}, "audio_only"},
+		{"500p", []string{"audio", "160p", "360p", "720p", "1080p60", "480p", "720p60", "worst", "best", "audio_only"}, "best"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Target: %s", test.target), func(t *testing.T) {
+			result := SelectClosestQuality(test.target, test.options)
+			if result != test.expected {
+				t.Errorf("For target %s, expected %s but got %s", test.target, test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Instead of hard-coding the many different quality/resolution values (e.g. `720p`, `720p60`, `1080p`, `1080p60`), strip the FPS values from the frontend and only show the resolution. Before the video is downloaded the video is checked for available resolutions and the closest one from the user's selected is used. 
If I archive a VOD with the quality `720p` then the closest `720p` resolution will be used, meaning `720p60` (preferred) or `720p30`, depending on what is available for the video.