### PR TITLE
feat(live): update chapters for live streams during live stream check

### DIFF
--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -35,7 +35,7 @@ const SearchPage = () => {
 
   const parseQuery = (q: SearchField) => {
     const m = q.match(/^(\w+):(.+)$/);
-    console.debug("parsedQuery", q, m);
+    console.log("parsedQuery", q, m);
     return m
       ? { field: m[1] as SearchField, query: m[2] }
       : { field: "title" as SearchField, query: q };

--- a/internal/chapter/chapter.go
+++ b/internal/chapter/chapter.go
@@ -47,6 +47,15 @@ func (s *Service) CreateChapter(c Chapter, videoId uuid.UUID) (*ent.Chapter, err
 	return dbChapter, nil
 }
 
+func (s *Service) UpdateChapter(c Chapter, chapterId uuid.UUID) (*ent.Chapter, error) {
+	dbChapter, err := s.Store.Client.Chapter.UpdateOneID(chapterId).SetType(c.Type).SetTitle(c.Title).SetStart(c.Start).SetEnd(c.End).Save(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("error updating chapter: %v", err)
+	}
+
+	return dbChapter, nil
+}
+
 func (s *Service) GetVideoChapters(videoId uuid.UUID) ([]*ent.Chapter, error) {
 	chapters, err := s.Store.Client.Chapter.Query().Where(entChapter.HasVodWith(vod.ID(videoId))).All(context.Background())
 	if err != nil {

--- a/internal/chat/ffz.go
+++ b/internal/chat/ffz.go
@@ -100,7 +100,7 @@ func GetFFZChannelEmotes(ctx context.Context, channelId string) ([]platform.Emot
 
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Error().Err(err)
+			log.Debug().Err(err).Msg("failed to close response body")
 		}
 	}()
 

--- a/internal/chat/seventv.go
+++ b/internal/chat/seventv.go
@@ -159,7 +159,7 @@ func Get7TVGlobalEmotes(ctx context.Context) ([]platform.Emote, error) {
 
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Error().Err(err)
+			log.Debug().Err(err).Msg("error closing response body")
 		}
 	}()
 
@@ -210,7 +210,7 @@ func Get7TVChannelEmotes(ctx context.Context, channelId string) ([]platform.Emot
 
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Error().Err(err)
+			log.Debug().Err(err).Msg("error closing response body")
 		}
 	}()
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -39,7 +39,7 @@ func DownloadTwitchVideo(ctx context.Context, video ent.Vod) error {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.Error().Err(err).Msg("failed to close log file")
+			log.Debug().Err(err).Msg("failed to close log file")
 		}
 	}()
 	log.Debug().Str("video_id", video.ID.String()).Msgf("logging streamlink output to %s", logFilePath)
@@ -168,7 +168,7 @@ func DownloadTwitchLiveVideo(ctx context.Context, video ent.Vod, channel ent.Cha
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.Error().Err(err).Msg("failed to close log file")
+			log.Debug().Err(err).Msg("failed to close log file")
 		}
 	}()
 	log.Debug().Str("video_id", video.ID.String()).Msgf("logging streamlink output to %s", logFilePath)
@@ -326,7 +326,7 @@ func PostProcessVideo(ctx context.Context, video ent.Vod) error {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.Error().Err(err).Msg("failed to close log file")
+			log.Debug().Err(err).Msg("failed to close log file")
 		}
 	}()
 	log.Debug().Str("video_id", video.ID.String()).Msgf("logging ffmpeg output to %s", logFilePath)
@@ -379,7 +379,7 @@ func ConvertVideoToHLS(ctx context.Context, video ent.Vod) error {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.Error().Err(err).Msg("failed to close log file")
+			log.Debug().Err(err).Msg("failed to close log file")
 		}
 	}()
 
@@ -431,7 +431,7 @@ func DownloadTwitchChat(ctx context.Context, video ent.Vod) error {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.Error().Err(err).Msg("failed to close log file")
+			log.Debug().Err(err).Msg("failed to close log file")
 		}
 	}()
 	log.Debug().Str("video_id", video.ID.String()).Msgf("logging streamlink output to %s", logFilePath)
@@ -496,7 +496,7 @@ func DownloadTwitchLiveChat(ctx context.Context, video ent.Vod, channel ent.Chan
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.Error().Err(err).Msg("failed to close log file")
+			log.Debug().Err(err).Msg("failed to close log file")
 		}
 	}()
 	log.Debug().Str("video_id", video.ID.String()).Msgf("logging chat downloader output to %s", logFilePath)
@@ -557,7 +557,7 @@ func RenderTwitchChat(ctx context.Context, video ent.Vod) error {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.Error().Err(err).Msg("failed to close log file")
+			log.Debug().Err(err).Msg("failed to close log file")
 		}
 	}()
 	log.Debug().Str("video_id", video.ID.String()).Msgf("logging chat_downloader output to %s", logFilePath)
@@ -629,7 +629,7 @@ func checkLogForNoElements(logFilePath string) (bool, error) {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.Error().Err(err).Msg("failed to close log file")
+			log.Debug().Err(err).Msg("failed to close log file")
 		}
 	}()
 
@@ -673,7 +673,7 @@ func UpdateTwitchChat(ctx context.Context, video ent.Vod) error {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.Error().Err(err).Msg("failed to close log file")
+			log.Debug().Err(err).Msg("failed to close log file")
 		}
 	}()
 	log.Debug().Str("video_id", video.ID.String()).Msgf("logging TwitchDownloader output to %s", logFilePath)
@@ -730,7 +730,7 @@ func checkLogForNoStreams(logFilePath string) (bool, error) {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.Error().Err(err)
+			log.Debug().Err(err)
 		}
 	}()
 
@@ -771,7 +771,7 @@ func ConvertTwitchVodVideo(v *ent.Vod) error {
 	}
 	defer func() {
 		if err := videoConvertLogfile.Close(); err != nil {
-			log.Error().Err(err).Msg("error closing video convert logfile")
+			log.Debug().Err(err).Msg("error closing video convert logfile")
 		}
 	}()
 	cmd.Stdout = videoConvertLogfile
@@ -826,7 +826,7 @@ func testProxyServer(url string, header string) bool {
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Error().Err(err).Msg("error closing response body for proxy server test")
+			log.Debug().Err(err).Msg("error closing response body for proxy server test")
 		}
 	}()
 	if resp.StatusCode != 200 {

--- a/internal/exec/thumbnails.go
+++ b/internal/exec/thumbnails.go
@@ -107,7 +107,7 @@ func CreateSprites(config CreateSpritesInput) ([]string, error) {
 			}
 			defer func() {
 				if err := file.Close(); err != nil {
-					log.Error().Err(err)
+					log.Debug().Err(err).Msg("failed to close thumbnail file")
 				}
 			}()
 
@@ -131,7 +131,7 @@ func CreateSprites(config CreateSpritesInput) ([]string, error) {
 		}
 		defer func() {
 			if err := spriteFile.Close(); err != nil {
-				fmt.Printf("failed to close sprite file %s: %v\n", spritePath, err)
+				log.Debug().Err(err).Msg("failed to close sprite file")
 			}
 		}()
 

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -433,6 +433,9 @@ func (s *Service) updateLiveStreamArchiveChapter(stream platform.LiveStreamInfo)
 		End:   seconds,
 		Title: lastChapter.Title,
 	}, lastChapter.ID)
+	if err != nil {
+		return err
+	}
 
 	// Create new chapter
 	_, err = s.ChapterService.CreateChapter(chapter.Chapter{
@@ -442,7 +445,6 @@ func (s *Service) updateLiveStreamArchiveChapter(stream platform.LiveStreamInfo)
 		Title: stream.GameName,
 	}, video.ID)
 	if err != nil {
-		log.Error().Err(err).Msg("error creating new chapter")
 		return err
 	}
 

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zibbp/ganymede/ent/queue"
 	entVod "github.com/zibbp/ganymede/ent/vod"
 	"github.com/zibbp/ganymede/internal/archive"
+	"github.com/zibbp/ganymede/internal/chapter"
 	"github.com/zibbp/ganymede/internal/database"
 	"github.com/zibbp/ganymede/internal/notification"
 	"github.com/zibbp/ganymede/internal/platform"
@@ -29,6 +30,7 @@ type Service struct {
 	Store          *database.Database
 	ArchiveService *archive.Service
 	PlatformTwitch platform.Platform
+	ChapterService *chapter.Service
 }
 
 type Live struct {
@@ -70,8 +72,8 @@ type ArchiveLive struct {
 	RenderChat  bool      `json:"render_chat"`
 }
 
-func NewService(store *database.Database, archiveService *archive.Service, platformTwitch platform.Platform) *Service {
-	return &Service{Store: store, ArchiveService: archiveService, PlatformTwitch: platformTwitch}
+func NewService(store *database.Database, archiveService *archive.Service, platformTwitch platform.Platform, chapterService *chapter.Service) *Service {
+	return &Service{Store: store, ArchiveService: archiveService, PlatformTwitch: platformTwitch, ChapterService: chapterService}
 }
 
 func (s *Service) GetLiveWatchedChannels(c echo.Context) ([]*ent.Live, error) {
@@ -248,9 +250,17 @@ OUTER:
 		// Check if LWC is in twitchStreams.Data
 		stream := channelInLiveStreamInfo(lwc.Edges.Channel.Name, streams)
 		if len(stream.ID) > 0 {
+			// Run chapter update - this needs to be done before additional checks to cover the case where a stream is being archived but fails restriction checks
+			// It also needs to run before live watched channel "isLive" check and this should run every time live streams are checked
+			err = s.updateLiveStreamArchiveChapter(stream)
+			if err != nil {
+				log.Error().Err(err).Msg("error updating live stream archive chapter")
+			}
+
 			if !lwc.IsLive {
 				// stream is live
 				log.Debug().Str("channel", lwc.Edges.Channel.Name).Msg("stream is live; checking for restrictions before archiving")
+
 				// check for any user-constraints before archiving
 				if len(lwc.Edges.TitleRegex) > 0 {
 					// run regexes against title
@@ -329,12 +339,24 @@ OUTER:
 
 				// Notification
 				// Fetch channel for notification
-				vod, err := s.Store.Client.Vod.Query().Where(entVod.ExtStreamID(stream.ID)).WithChannel().WithQueue().Order(ent.Desc(entVod.FieldCreatedAt)).Limit(1).First(ctx)
+				vod, err := s.Store.Client.Vod.Query().Where(entVod.ExtStreamID(stream.ID)).WithChannel().WithQueue().Order(ent.Desc(entVod.FieldCreatedAt)).First(ctx)
 				if err != nil {
 					log.Error().Err(err).Msg("error getting vod")
 					continue
 				}
 				go notification.SendLiveNotification(lwc.Edges.Channel, vod, vod.Edges.Queue, stream.GameName)
+
+				// Create initial chapter
+				_, err = s.ChapterService.CreateChapter(chapter.Chapter{
+					Type:  "GAME_CHANGE",
+					Start: 0,
+					End:   0,
+					Title: stream.GameName,
+				}, vod.ID)
+				if err != nil {
+					log.Error().Err(err).Msg("error creating initial chapter")
+				}
+
 			}
 		} else {
 			if lwc.IsLive {
@@ -358,4 +380,72 @@ func channelInLiveStreamInfo(a string, list []platform.LiveStreamInfo) platform.
 		}
 	}
 	return platform.LiveStreamInfo{}
+}
+
+// updateLiveStreamArchiveChapter updates the last chapter of a live stream archive if the category has changed.
+func (s *Service) updateLiveStreamArchiveChapter(stream platform.LiveStreamInfo) error {
+	// Get video
+	video, err := s.Store.Client.Vod.Query().Where(entVod.ExtStreamID(stream.ID)).Order(ent.Desc(entVod.FieldCreatedAt)).First(context.Background())
+	if err != nil {
+		if _, ok := err.(*ent.NotFoundError); ok {
+			// Video not found, likely not archived yet because of restrictions
+			return nil
+		}
+		log.Error().Err(err).Msg("error getting video")
+		return err
+	}
+
+	// Get vod chapters
+	chapters, err := s.ChapterService.GetVideoChapters(video.ID)
+	if err != nil {
+		return err
+	}
+
+	// Get the last chapter by start time
+	var lastChapter *ent.Chapter
+	if len(chapters) == 1 {
+		lastChapter = chapters[0]
+	} else {
+		for _, chapter := range chapters {
+			if lastChapter == nil || chapter.Start > lastChapter.Start {
+				lastChapter = chapter
+			}
+		}
+	}
+
+	if lastChapter == nil {
+		log.Debug().Msgf("no chapters found for video %s", video.ID)
+		return nil
+	}
+
+	// Check if new chapter is needed
+	if lastChapter.Title == stream.GameName {
+		log.Debug().Msgf("no new chapter needed for video %s", video.ID)
+		return nil
+	}
+
+	// New chapter needed, update last chapter end time to current time
+	duration := time.Since(video.CreatedAt).Seconds()
+	seconds := int(duration)
+	lastChapter, err = s.ChapterService.UpdateChapter(chapter.Chapter{
+		Type:  lastChapter.Type,
+		Start: lastChapter.Start,
+		End:   seconds,
+		Title: lastChapter.Title,
+	}, lastChapter.ID)
+
+	// Create new chapter
+	_, err = s.ChapterService.CreateChapter(chapter.Chapter{
+		Type:  "GAME_CHANGE",
+		Start: lastChapter.End,
+		End:   0,
+		Title: stream.GameName,
+	}, video.ID)
+	if err != nil {
+		log.Error().Err(err).Msg("error creating new chapter")
+		return err
+	}
+
+	log.Info().Msgf("updated chapter %s -> %s for live stream %s", lastChapter.Title, stream.GameName, video.ID)
+	return nil
 }

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -42,7 +42,7 @@ func sendWebhook(url string, body []byte) error {
 
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Error().Err(err).Msg("error closing response body")
+			log.Debug().Err(err).Msg("error closing response body")
 		}
 	}()
 

--- a/internal/platform/twitch_api.go
+++ b/internal/platform/twitch_api.go
@@ -197,7 +197,7 @@ func twitchAuthenticate(clientId string, clientSecret string) (*AuthTokenRespons
 
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("failed to close response body: %v\n", err)
+			log.Debug().Err(err).Msg("error closing response body")
 		}
 	}()
 	if resp.StatusCode != http.StatusOK {
@@ -245,7 +245,7 @@ func (c *TwitchConnection) twitchMakeHTTPRequest(method, url string, queryParams
 		}
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
-				fmt.Printf("failed to close response body: %v\n", err)
+				log.Debug().Err(err).Msg("error closing response body")
 			}
 		}()
 

--- a/internal/platform/twitch_gql.go
+++ b/internal/platform/twitch_gql.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/zibbp/ganymede/internal/chapter"
 )
 
@@ -151,7 +152,7 @@ func twitchGQLRequest(body string) ([]byte, error) {
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("error closing response body: %v\n", err)
+			log.Debug().Err(err).Msg("error closing response body")
 		}
 	}()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -147,12 +147,12 @@ func SetupApplication(ctx context.Context) (*Application, error) {
 	archiveService := archive.NewService(db, channelService, vodService, queueService, blockedVodService, riverClient, platformTwitch)
 	adminService := admin.NewService(db)
 	userService := user.NewService(db)
-	liveService := live.NewService(db, archiveService, platformTwitch)
+	chapterService := chapter.NewService(db)
+	liveService := live.NewService(db, archiveService, platformTwitch, chapterService)
 	playbackService := playback.NewService(db)
 	metricsService := metrics.NewService(db, riverClient)
 	playlistService := playlist.NewService(db)
 	taskService := task.NewService(db, liveService, riverClient)
-	chapterService := chapter.NewService(db)
 	categoryService := category.NewService(db)
 
 	return &Application{

--- a/internal/tasks/video.go
+++ b/internal/tasks/video.go
@@ -172,6 +172,26 @@ func (w PostProcessVideoWorker) Work(ctx context.Context, job *river.Job[PostPro
 		if err != nil {
 			return err
 		}
+
+		// Update last chapter end time for live stream archive
+		videoChapters, err := dbItems.Video.QueryChapters().All(ctx)
+		if err != nil {
+			return err
+		}
+		fmt.Println(videoChapters)
+
+		if len(videoChapters) > 0 {
+			for _, chapter := range videoChapters {
+				fmt.Println(chapter)
+				if chapter.End == 0 {
+					fmt.Println("updating chapter end time")
+					_, err = chapter.Update().SetEnd(duration).Save(ctx)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
 	}
 
 	// convert to HLS if needed

--- a/internal/twitch/graphql.go
+++ b/internal/twitch/graphql.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 )
 
 type GQLVideoResponse struct {
@@ -148,7 +150,7 @@ func gqlRequest(body string) ([]byte, error) {
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("error closing response body: %v\n", err)
+			log.Debug().Err(err).Msg("error closing response body")
 		}
 	}()
 

--- a/internal/twitch/twitch.go
+++ b/internal/twitch/twitch.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+
+	"github.com/rs/zerolog/log"
 )
 
 // CheckUserAccessToken checks if the access token is valid by sending a GET request to the Twitch API
@@ -22,7 +24,7 @@ func CheckUserAccessToken(ctx context.Context, accessToken string) error {
 
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("failed to close response body: %v\n", err)
+			log.Debug().Err(err).Msg("error closing response body")
 		}
 	}()
 

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -42,7 +42,7 @@ func DownloadAndSaveFile(url, path string) error {
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Error().Err(err).Msg("error closing response body")
+			log.Debug().Err(err).Msg("error closing response body")
 		}
 	}()
 
@@ -58,7 +58,7 @@ func DownloadAndSaveFile(url, path string) error {
 	}
 	defer func() {
 		if err := out.Close(); err != nil {
-			log.Error().Err(err).Msg("error closing file")
+			log.Debug().Err(err).Msg("error closing file")
 		}
 	}()
 
@@ -81,7 +81,7 @@ func DownloadFile(url, path string) error {
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Error().Err(err).Msg("error closing response body")
+			log.Debug().Err(err).Msg("error closing response body")
 		}
 	}()
 	if resp.StatusCode != http.StatusOK {
@@ -95,7 +95,7 @@ func DownloadFile(url, path string) error {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.Error().Err(err).Msg("error closing file")
+			log.Debug().Err(err).Msg("error closing file")
 		}
 	}()
 
@@ -137,7 +137,7 @@ func MoveFile(ctx context.Context, source, dest string) error {
 	}
 	defer func() {
 		if err := srcFile.Close(); err != nil {
-			log.Error().Err(err).Msg("error closing source file")
+			log.Debug().Msg("error closing source file")
 		}
 	}()
 
@@ -147,7 +147,7 @@ func MoveFile(ctx context.Context, source, dest string) error {
 	}
 	defer func() {
 		if err := destFile.Close(); err != nil {
-			log.Error().Err(err).Msg("error closing destination file")
+			log.Debug().Err(err).Msg("error closing destination file")
 		}
 	}()
 
@@ -168,7 +168,7 @@ func MoveFile(ctx context.Context, source, dest string) error {
 	// Close files before attempting to remove the source
 	err = srcFile.Close()
 	if err != nil {
-		log.Error().Err(err).Msg("error closing source file after copy")
+		log.Debug().Msg("error closing source file after copy")
 	}
 	err = destFile.Close()
 	if err != nil {
@@ -213,7 +213,7 @@ func CopyFile(sourcePath, destPath string) error {
 	}
 	defer func() {
 		if err := outputFile.Close(); err != nil {
-			log.Error().Err(err).Msg("error closing output file")
+			log.Debug().Err(err).Msg("error closing output file")
 		}
 	}()
 	_, err = io.Copy(outputFile, inputFile)
@@ -307,7 +307,7 @@ func MoveFolder(src string, dst string) error {
 		}
 		defer func() {
 			if err := srcFile.Close(); err != nil {
-				log.Error().Err(err).Msg("error closing source file")
+				log.Debug().Msg("error closing source file")
 			}
 		}()
 
@@ -318,7 +318,7 @@ func MoveFolder(src string, dst string) error {
 		}
 		defer func() {
 			if err := dstFile.Close(); err != nil {
-				log.Error().Err(err).Msg("error closing destination file")
+				log.Debug().Msg("error closing destination file")
 			}
 		}()
 

--- a/internal/utils/live_chat.go
+++ b/internal/utils/live_chat.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/rs/zerolog/log"
 )
 
 type LiveComment struct {
@@ -64,7 +66,7 @@ func OpenLiveChatFile(path string) ([]LiveComment, error) {
 	}
 	defer func() {
 		if err := liveChatJsonFile.Close(); err != nil {
-			fmt.Printf("failed to close chat file: %v", err)
+			log.Debug().Err(err).Msg("error closing chat file")
 		}
 	}()
 	byteValue, _ := io.ReadAll(liveChatJsonFile)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zibbp/ganymede/internal/archive"
 	"github.com/zibbp/ganymede/internal/blocked"
 	"github.com/zibbp/ganymede/internal/channel"
+	"github.com/zibbp/ganymede/internal/chapter"
 	"github.com/zibbp/ganymede/internal/config"
 	"github.com/zibbp/ganymede/internal/database"
 	"github.com/zibbp/ganymede/internal/live"
@@ -70,13 +71,14 @@ func SetupWorker(ctx context.Context) (*tasks_worker.RiverWorkerClient, error) {
 		}
 	}
 
+	chapterService := chapter.NewService(db)
 	channelService := channel.NewService(db, platformTwitch)
 	vodService := vod.NewService(db, riverClient, platformTwitch)
 	queueService := queue.NewService(db, vodService, channelService, riverClient)
 	blockedVodsService := blocked.NewService(db)
 	// twitchService := twitch.NewService()
 	archiveService := archive.NewService(db, channelService, vodService, queueService, blockedVodsService, riverClient, platformTwitch)
-	liveService := live.NewService(db, archiveService, platformTwitch)
+	liveService := live.NewService(db, archiveService, platformTwitch, chapterService)
 
 	// initialize river
 	riverWorkerClient, err := tasks_worker.NewRiverWorker(tasks_worker.RiverWorkerInput{


### PR DESCRIPTION
- Every time the live stream channel check runs, check all live streams and update the chapters if necessary. This means live streams (through watched channels only) will have chapters (categories).
- Update file close defer functions to debug instead of error