### PR TITLE
force login fixes

### DIFF
--- a/frontend/app/components/authentication/ForceLogin.tsx
+++ b/frontend/app/components/authentication/ForceLogin.tsx
@@ -22,8 +22,8 @@ export default function ForceLogin({ children }: { children: React.ReactNode }) 
   }, [isLoggedIn, isLoading, isAuthPage, router]);
 
   if (isForceLoginEnabled && !isAuthPage) {
-    if (isLoading) return null;
-    if (!isLoggedIn) return null;
+    if (isLoading) return <div></div>;
+    if (!isLoggedIn) return <div></div>;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
Returning `null` worked fine in dev mode. When built and deployed it messed up hydration. Return an empty div instead.