### PR TITLE
feat: additional 'is live' check

### DIFF
--- a/internal/platform/interfaces.go
+++ b/internal/platform/interfaces.go
@@ -133,4 +133,5 @@ type Platform interface {
 	GetChannelEmotes(ctx context.Context, channelId string) ([]Emote, error)
 	GetChannelClips(ctx context.Context, channelId string, filter ClipsFilter) ([]ClipInfo, error)
 	GetClip(ctx context.Context, id string) (*ClipInfo, error)
+	CheckIfStreamIsLive(ctx context.Context, channelName string) (bool, error)
 }

--- a/internal/platform/twitch.go
+++ b/internal/platform/twitch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -777,4 +778,38 @@ func (c *TwitchConnection) GetClip(ctx context.Context, id string) (*ClipInfo, e
 	}
 
 	return &info, nil
+}
+
+// CheckIfStreamIsLive checks if a Twitch stream is live by attempting to parse the m3u8 playlist of the stream.
+func (c *TwitchConnection) CheckIfStreamIsLive(ctx context.Context, channelName string) (bool, error) {
+	token, err := c.TwitchGQLGetPlaybackAccessToken(channelName)
+	if err != nil {
+		log.Panic().Err(err).Msg("Error getting playback access token")
+	}
+	// Construct the m3u8 URL for the stream
+	m3u8URL := fmt.Sprintf("https://usher.ttvnw.net/api/channel/hls/%s.m3u8?sig=%s&token=%s", channelName, token.Signature, token.Value)
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	// HTTP request to fetch the m3u8 playlist
+	req, err := http.NewRequest("GET", m3u8URL, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create request: %v", err)
+	}
+	req.Header.Set("User-Agent", utils.ChromeUserAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch m3u8 playlist: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// If the response status is not 200 or 403 the stream is not live
+	// This request is not authenticated, so it can return 403 if the stream is sub-only or geo-blocked
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusForbidden {
+		return false, fmt.Errorf("received unexpected status code: %d", resp.StatusCode)
+	}
+
+	return true, nil
 }

--- a/internal/platform/twitch.go
+++ b/internal/platform/twitch.go
@@ -803,7 +803,7 @@ func (c *TwitchConnection) CheckIfStreamIsLive(ctx context.Context, channelName 
 	if err != nil {
 		return false, fmt.Errorf("failed to fetch m3u8 playlist: %v", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	// If the response status is not 200 or 403 the stream is not live
 	// This request is not authenticated, so it can return 403 if the stream is sub-only or geo-blocked

--- a/internal/platform/twitch.go
+++ b/internal/platform/twitch.go
@@ -784,7 +784,7 @@ func (c *TwitchConnection) GetClip(ctx context.Context, id string) (*ClipInfo, e
 func (c *TwitchConnection) CheckIfStreamIsLive(ctx context.Context, channelName string) (bool, error) {
 	token, err := c.TwitchGQLGetPlaybackAccessToken(channelName)
 	if err != nil {
-		log.Panic().Err(err).Msg("Error getting playback access token")
+		return false, fmt.Errorf("failed to get playback access token: %v", err)
 	}
 	// Construct the m3u8 URL for the stream
 	m3u8URL := fmt.Sprintf("https://usher.ttvnw.net/api/channel/hls/%s.m3u8?sig=%s&token=%s", channelName, token.Signature, token.Value)

--- a/internal/twitch/graphql.go
+++ b/internal/twitch/graphql.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
+	"github.com/zibbp/ganymede/internal/utils"
 )
 
 type GQLVideoResponse struct {
@@ -142,7 +143,7 @@ func gqlRequest(body string) ([]byte, error) {
 	req.Header.Set("Referer", "https://www.twitch.tv/")
 	req.Header.Set("Sec-Fetch-Mode", "cors")
 	req.Header.Set("Sec-Fetch-Site", "same-site")
-	// req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36")
+	req.Header.Set("User-Agent", utils.ChromeUserAgent)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -1,0 +1,3 @@
+package utils
+
+var ChromeUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"


### PR DESCRIPTION
#760

The Twitch API can be very slow to update when a stream ends. This causes a disconnect between the API and the actual m3u8 stream. Implement a check to see if the m3u8 playlist returns a 200 response (channel is live).