### PR TITLE
fix(vod): use video hls path when deleting vods if hls video

### DIFF
--- a/internal/vod/vod.go
+++ b/internal/vod/vod.go
@@ -208,6 +208,11 @@ func (s *Service) DeleteVod(c echo.Context, vodID uuid.UUID, deleteFiles bool) e
 
 		path := filepath.Dir(filepath.Clean(v.VideoPath))
 
+		// If video was converted to HLS need to use the HLS path
+		if v.VideoHlsPath != "" {
+			path = filepath.Dir(filepath.Clean(v.VideoHlsPath))
+		}
+
 		if err := utils.DeleteDirectory(path); err != nil {
 			log.Error().Err(err).Msg("error deleting directory")
 			return fmt.Errorf("error deleting directory: %v", err)

--- a/internal/vod/vod.go
+++ b/internal/vod/vod.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -204,14 +205,25 @@ func (s *Service) DeleteVod(c echo.Context, vodID uuid.UUID, deleteFiles bool) e
 
 	// delete files
 	if deleteFiles {
-		log.Debug().Msgf("deleting files for vod %s", v.ID)
+		log.Info().Msgf("deleting files for vod %s", v.ID)
 
-		path := filepath.Dir(filepath.Clean(v.VideoPath))
-
-		// If video was converted to HLS need to use the HLS path
+		videoPath := v.VideoPath
 		if v.VideoHlsPath != "" {
-			path = filepath.Dir(filepath.Clean(v.VideoHlsPath))
+			videoPath = v.VideoHlsPath
 		}
+
+		path := filepath.Dir(filepath.Clean(videoPath))
+
+		// Make sure FolderName is present in the path before deleting
+		// This is to prevent accidental deletion of unrelated directories
+		if v.FolderName != "" {
+			if !strings.Contains(path, v.FolderName) {
+				log.Warn().Msgf("video folder_name not found in path, cowardly refusing to delete: %s. Delete video without deleting files then manually delete directory", path)
+				return fmt.Errorf("video folder_name not found in path, cowardly refusing to delete: %s. Delete video without deleting files then manually delete directory", path)
+			}
+		}
+
+		log.Info().Msgf("deleting directory %s", path)
 
 		if err := utils.DeleteDirectory(path); err != nil {
 			log.Error().Err(err).Msg("error deleting directory")

--- a/internal/vod/vod.go
+++ b/internal/vod/vod.go
@@ -207,6 +207,8 @@ func (s *Service) DeleteVod(c echo.Context, vodID uuid.UUID, deleteFiles bool) e
 	if deleteFiles {
 		log.Info().Msgf("deleting files for vod %s", v.ID)
 
+		// Use the videopath for standard videos
+		// If HLS video use the path of the HLS directory
 		videoPath := v.VideoPath
 		if v.VideoHlsPath != "" {
 			videoPath = v.VideoHlsPath


### PR DESCRIPTION
Fixes https://github.com/Zibbp/ganymede/issues/802

- Fix bug with HLS videos where the base path was being calculated within the HLS subdir
- Add a safety check to ensure the directory being recursively deleted contains the video `folder_name`. If it does not the delete does not proceed