### PR TITLE
Extend translation-coverage.js to allow auto-updating translation files

### DIFF
--- a/frontend/translation-coverage.js
+++ b/frontend/translation-coverage.js
@@ -15,6 +15,14 @@ if (process.stdout.isTTY) {
   color_cyan = "";
 }
 
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+  console.log(`-h, --help                 Print this help message`);
+  console.log(`-u, --update-translations  Update translation files in the frontend/messages directory with missing keys`);
+  process.exit(0);
+}
+
+const argUpdateTranslations = process.argv.includes("--update-translations") || process.argv.includes("-u");
+
 console.log(`${color_cyan}Translation coverage report for frontend/messages/*.json${color_reset}`);
 
 // Helper to flatten nested keys
@@ -30,35 +38,66 @@ function flatten(obj, prefix = "") {
   }, {});
 }
 
+function deepMerge(target, source) {
+    if (typeof target !== 'object' || target === null || typeof source !== 'object' || source === null) {
+        throw new TypeError('Both arguments must be objects');
+    }
+
+    for (let key in source) {
+        if (source.hasOwnProperty(key)) {
+            const srcValue = source[key];
+            const tgtValue = target[key];
+
+            if (tgtValue && typeof tgtValue === 'object' && !Array.isArray(tgtValue) &&
+                srcValue && typeof srcValue === 'object' && !Array.isArray(srcValue)) {
+
+                // Recursively merge nested objects
+                deepMerge(tgtValue, srcValue);
+            } else {
+                // Set the property if it doesn't exist in target or if it's not an object
+                target[key] = srcValue;
+            }
+        }
+    }
+
+    return target;
+}
+
 const baseLocale = "en";
 const localesDir = path.join(__dirname, "messages");
 
-const baseMessages = flatten(
-  JSON.parse(fs.readFileSync(`${localesDir}/${baseLocale}.json`, "utf-8"))
-);
+const baseLanguageObject = JSON.parse(fs.readFileSync(`${localesDir}/${baseLocale}.json`, "utf-8"));
+const baseMessages = flatten(structuredClone(baseLanguageObject));
 const baseKeys = Object.keys(baseMessages);
 
 let translationStats = {};
 let extraKeysInTargetLocales = {};
 let missingKeysInTargetLocales = {};
+let updatedTargetTranslationFiles = [];
 fs.readdirSync(localesDir).forEach((file) => {
   const locale = path.basename(file, ".json");
   if (locale === baseLocale) return;
 
-  const targetMessages = flatten(
-    JSON.parse(fs.readFileSync(`${localesDir}/${file}`, "utf-8"))
-  );
+  const targetLanguageFile = `${localesDir}/${file}`;
+  const targetLanguageObject = JSON.parse(fs.readFileSync(targetLanguageFile, "utf-8"));
+  if (argUpdateTranslations) {
+    let newTargetLanguageObject = structuredClone(baseLanguageObject)
+    deepMerge(newTargetLanguageObject, targetLanguageObject);
+    fs.writeFileSync(
+      file = targetLanguageFile,
+      data = JSON.stringify(newTargetLanguageObject, null, 2),
+      options = { encoding: "utf-8" },
+    );
+    updatedTargetTranslationFiles.push(targetLanguageFile);
+  }
+  const targetMessages = flatten(structuredClone(targetLanguageObject));
   extraKeysInTargetLocales[locale] = Object.keys(targetMessages).filter(
     (key) => !baseKeys.includes(key)
   );
   const translatedKeys = Object.keys(targetMessages);
   const missingKeys = baseKeys.filter((key) => !translatedKeys.includes(key));
   if (missingKeys.length > 0) {
-  //   console.log(`Missing translations in "${locale}":`);
     missingKeysInTargetLocales[locale] = missingKeys;
-    // missingKeys.forEach((key) => {
-    //   console.log(`- ${key}`);
-    // });
   }
 
   const translatedCount = baseKeys.filter((key) => targetMessages[key]).length;
@@ -96,6 +135,13 @@ if (localesWithExtraKeys.length > 0) {
       console.warn(`  - ${key}`);
     });
   });
+  // add final newline for better readability
+  console.log('');
+}
+
+if (argUpdateTranslations) {
+  console.log(`${color_yellow}${updatedTargetTranslationFiles.length}${color_reset} translation files have been updated, please translate them:`);
+  updatedTargetTranslationFiles.forEach((file) => console.log(`- ${file}`));
   // add final newline for better readability
   console.log('');
 }


### PR DESCRIPTION
This removes the need to manually create / update the translation files when new keys or whole objects are added. This makes it easy to update translation files, just look at the git changes and update the translations accordingly.

NOTE: Subsequent translation coverage runs will report 100% coverage, since
      all keys are present now.