### PR TITLE
feat: add granular date variables for storage templates

### DIFF
--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -163,7 +163,7 @@ const AdminSettingsPage = () => {
               {t('applicationSettings.notificationSettingsButton')}
             </Button>
 
-            <Collapse in={notificationsOpened}>
+            <Collapse in={notificationsOpened} px={25} pt={10}>
               <Text>Must be a webhook URL or an Apprise HTTP URL, visit the <a href="https://github.com/Zibbp/ganymede/wiki/Notifications" target="_blank">wiki</a> for more information.</Text>
 
               {/* video archive success */}
@@ -403,7 +403,7 @@ const AdminSettingsPage = () => {
               {t('archiveSettings.storageTemplateSettings')}
             </Button>
 
-            <Collapse in={storageTemplateOpened}>
+            <Collapse in={storageTemplateOpened} px={25} pt={10}>
 
               <div>
                 <Text mb={10}>
@@ -426,7 +426,7 @@ const AdminSettingsPage = () => {
                   </Title>
 
                   <Textarea
-                    description="Do not include the file extension. The file type will be appened to the end of the file name such as -video -chat and -thumbnail."
+                    description="Do not include the file extension. The file type will be appended to the end of the file name such as -video -chat and -thumbnail."
                     key={form.key('storage_templates.file_template')}
                     {...form.getInputProps('storage_templates.file_template')}
                     required
@@ -440,13 +440,22 @@ const AdminSettingsPage = () => {
 
                   <div>
                     <Text>Ganymede</Text>
-                    <Code>{"{{uuid}}"}</Code>
-                    <Text>Twitch Video</Text>
-                    <Code>{"{{id}} {{channel}} {{title}} {{date}} {{type}}"}</Code>
-                    <Text ml={20} mt={5} size="sm">
-                      ID: Twitch video ID <br /> Date: Date streamed or uploaded <br />{" "}
-                      Type: Twitch video type (live, archive, highlight)
-                    </Text>
+                    <ul>
+                      <li><Code>{"{{uuid}}"}</Code>: Unique identifier for the archive</li>
+                    </ul>
+                    <Text>Video</Text>
+                    <ul>
+                      <li><Code>{"{{id}}"}</Code>: Video ID</li>
+                      <li><Code>{"{{channel}}"}</Code>: Channel name</li>
+                      <li><Code>{"{{title}}"}</Code>: Video title (file safe)</li>
+                      <li><Code>{"{{type}}"}</Code>: Video type (live, archive, highlight)</li>
+                      <li><Code>{"{{date}}"}</Code>: Formatted date (YYYY-MM-DD)</li>
+                      <li><Code>{"{{YYYY}}"}</Code>: Year</li>
+                      <li><Code>{"{{MM}}"}</Code>: Month</li>
+                      <li><Code>{"{{DD}}"}</Code>: Day</li>
+                      <li><Code>{"{{HH}}"}</Code>: Hour</li>
+                    </ul>
+
                   </div>
                 </div>
 

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -154,6 +154,10 @@ func (s *Service) ArchiveVideo(ctx context.Context, input ArchiveVideoInput) err
 		Title:   video.Title,
 		Type:    video.Type,
 		Date:    video.CreatedAt.Format("2006-01-02"),
+		YYYY:    video.CreatedAt.Format("2006"),
+		MM:      video.CreatedAt.Format("01"),
+		DD:      video.CreatedAt.Format("02"),
+		HH:      video.CreatedAt.Format("15"),
 	}
 	// Create directory paths
 	folderName, err := GetFolderName(vUUID, storageTemplateInput)
@@ -346,6 +350,10 @@ func (s *Service) ArchiveClip(ctx context.Context, input ArchiveClipInput) error
 		Title:   clip.Title,
 		Type:    string(utils.Clip),
 		Date:    clip.CreatedAt.Format("2006-01-02"),
+		YYYY:    clip.CreatedAt.Format("2006"),
+		MM:      clip.CreatedAt.Format("01"),
+		DD:      clip.CreatedAt.Format("02"),
+		HH:      clip.CreatedAt.Format("15"),
 	}
 	// Create directory paths
 	folderName, err := GetFolderName(vUUID, storageTemplateInput)
@@ -502,6 +510,10 @@ func (s *Service) ArchiveLivestream(ctx context.Context, input ArchiveVideoInput
 		Title:   video.Title,
 		Type:    video.Type,
 		Date:    video.StartedAt.Format("2006-01-02"),
+		YYYY:    video.StartedAt.Format("2006"),
+		MM:      video.StartedAt.Format("01"),
+		DD:      video.StartedAt.Format("02"),
+		HH:      video.StartedAt.Format("15"),
 	}
 	// Create directory paths
 	folderName, err := GetFolderName(vUUID, storageTemplateInput)

--- a/internal/archive/utils.go
+++ b/internal/archive/utils.go
@@ -22,6 +22,10 @@ type StorageTemplateInput struct {
 	Title   string
 	Type    string
 	Date    string // parsed date
+	YYYY    string // year
+	MM      string // month
+	DD      string // day
+	HH      string // hour
 }
 
 func GetFolderName(uuid uuid.UUID, input StorageTemplateInput) (string, error) {
@@ -98,6 +102,10 @@ func getVariableMap(uuid uuid.UUID, input StorageTemplateInput) (map[string]inte
 		"title":   safeTitle,
 		"date":    input.Date,
 		"type":    input.Type,
+		"YYYY":    input.YYYY,
+		"MM":      input.MM,
+		"DD":      input.DD,
+		"HH":      input.HH,
 	}
 	return variables, nil
 }

--- a/internal/archive/utils_test.go
+++ b/internal/archive/utils_test.go
@@ -39,7 +39,7 @@ func TestGetFolderName(t *testing.T) {
 	}{
 		{
 			name:        "default template",
-			template:    "",
+			template:    "{{date}}-{{id}}-{{type}}-{{uuid}}",
 			expected:    "2025-08-04-testid-video-123e4567-e89b-12d3-a456-426614174000",
 			expectError: false,
 		},
@@ -111,7 +111,7 @@ func TestGetFileName(t *testing.T) {
 	}{
 		{
 			name:        "default template",
-			template:    "",
+			template:    "{{id}}",
 			expected:    "testid",
 			expectError: false,
 		},

--- a/internal/archive/utils_test.go
+++ b/internal/archive/utils_test.go
@@ -1,0 +1,154 @@
+package archive_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/zibbp/ganymede/internal/archive"
+	"github.com/zibbp/ganymede/internal/config"
+	"github.com/zibbp/ganymede/tests"
+)
+
+// TestGetFolderName tests the GetFolderName function with various templates and inputs.
+func TestGetFolderName(t *testing.T) {
+	// Setup the application
+	_, err := tests.Setup(t)
+	assert.NoError(t, err)
+
+	// Setup test input
+	testUUID := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+	input := archive.StorageTemplateInput{
+		UUID:    testUUID,
+		ID:      "testid",
+		Channel: "testchannel",
+		Title:   "Test Title",
+		Type:    "video",
+		Date:    "2025-08-04",
+		YYYY:    "2025",
+		MM:      "08",
+		DD:      "04",
+		HH:      "12",
+	}
+
+	tests := []struct {
+		name        string
+		template    string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "default template",
+			template:    "",
+			expected:    "2025-08-04-testid-video-123e4567-e89b-12d3-a456-426614174000",
+			expectError: false,
+		},
+		{
+			name:        "custom template with variables",
+			template:    "{{channel}}_{{type}}_{{id}}_{{uuid}}",
+			expected:    "testchannel_video_testid_123e4567-e89b-12d3-a456-426614174000",
+			expectError: false,
+		},
+		{
+			name:        "custom template with granular date",
+			template:    "s{{YYYY}}{{MM}}-{{DD}}{{HH}} - {{title}}",
+			expected:    "s202508-0412 - Test_Title",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Update config with the template
+			if tt.template != "" {
+				c := config.Get()
+				c.StorageTemplates.FolderTemplate = tt.template
+				assert.NoError(t, config.UpdateConfig(c), "failed to update config with template")
+			}
+			result, err := archive.GetFolderName(testUUID, input)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("GetFolderName() = %q, expected %q", result, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+// TestGetFileName tests the GetFileName function with various templates and inputs.
+func TestGetFileName(t *testing.T) {
+	// Setup the application
+	_, err := tests.Setup(t)
+	assert.NoError(t, err)
+
+	// Setup test input
+	testUUID := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+	input := archive.StorageTemplateInput{
+		UUID:    testUUID,
+		ID:      "testid",
+		Channel: "testchannel",
+		Title:   "Test Title",
+		Type:    "video",
+		Date:    "2025-08-04",
+		YYYY:    "2025",
+		MM:      "08",
+		DD:      "04",
+		HH:      "12",
+	}
+
+	tests := []struct {
+		name        string
+		template    string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "default template",
+			template:    "",
+			expected:    "testid",
+			expectError: false,
+		},
+		{
+			name:        "custom template with variables",
+			template:    "{{channel}}_{{type}}_{{id}}_{{uuid}}.mp4",
+			expected:    "testchannel_video_testid_123e4567-e89b-12d3-a456-426614174000.mp4",
+			expectError: false,
+		},
+		{
+			name:        "custom template with granular date",
+			template:    "s{{YYYY}}{{MM}}-{{DD}}{{HH}} - {{title}}.mp4",
+			expected:    "s202508-0412 - Test_Title.mp4",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.template != "" {
+				c := config.Get()
+				c.StorageTemplates.FileTemplate = tt.template
+				assert.NoError(t, config.UpdateConfig(c), "failed to update config with template")
+			}
+			result, err := archive.GetFileName(testUUID, input)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("GetFileName() = %q, expected %q", result, tt.expected)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://github.com/Zibbp/ganymede/issues/832

Add the following new storage template variables:
- `{{YYYY}}`
- `{{MM}}`
- `{{DD}}`
- `{{HH}}`