### PR TITLE
feat(archive): create fallback chapter from video category/game if no chapters exist

### DIFF
--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -152,7 +152,7 @@ func TestArchiveVideo(t *testing.T) {
 	assert.Greater(t, webThumbnailFileInfo.Size(), int64(0), "Web thumbnail file should not be empty")
 
 	// Assert sprite thumbnail facts
-	v, err = app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).Only(context.Background())
+	v, err = app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
 	assert.Len(t, v.SpriteThumbnailsImages, 1, "Sprite thumbnails should be generated for videos")
@@ -205,7 +205,7 @@ func TestArchiveVideoNoChat(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Assert video was created
-	v, err := app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).Only(context.Background())
+	v, err := app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
 
@@ -275,7 +275,7 @@ func TestArchiveVideoNoChatRender(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Assert video was created
-	v, err := app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).Only(context.Background())
+	v, err := app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
 
@@ -350,7 +350,7 @@ func TestArchiveVideoHLS(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Assert video was created
-	v, err := app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).Only(context.Background())
+	v, err := app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
 
@@ -523,7 +523,7 @@ func TestArchiveVideoWithSpriteThumbnails(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Assert video was created
-	v, err := app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).Only(context.Background())
+	v, err := app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
 

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -105,6 +105,11 @@ func TestArchiveVideo(t *testing.T) {
 	// Wait for the video to be archived
 	tests_shared.WaitForArchiveCompletion(t, app, v.ID, TestArchiveTimeout)
 
+	// Requery video
+	v, err = app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
+
 	// Assert queue item was updated
 	q, err = app.Database.Client.Queue.Query().Where(queue.HasVodWith(vod.ID(v.ID))).Only(context.Background())
 	assert.NoError(t, err)
@@ -230,6 +235,11 @@ func TestArchiveVideoNoChat(t *testing.T) {
 	// Wait for the video to be archived
 	tests_shared.WaitForArchiveCompletion(t, app, v.ID, TestArchiveTimeout)
 
+	// Requery video
+	v, err = app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
+
 	// Assert queue item was updated
 	q, err = app.Database.Client.Queue.Query().Where(queue.HasVodWith(vod.ID(v.ID))).Only(context.Background())
 	assert.NoError(t, err)
@@ -299,6 +309,11 @@ func TestArchiveVideoNoChatRender(t *testing.T) {
 
 	// Wait for the video to be archived
 	tests_shared.WaitForArchiveCompletion(t, app, v.ID, TestArchiveTimeout)
+
+	// Requery video
+	v, err = app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
 
 	// Assert queue item was updated
 	q, err = app.Database.Client.Queue.Query().Where(queue.HasVodWith(vod.ID(v.ID))).Only(context.Background())
@@ -376,6 +391,11 @@ func TestArchiveVideoHLS(t *testing.T) {
 
 	// Wait for the video to be archived
 	tests_shared.WaitForArchiveCompletion(t, app, v.ID, TestArchiveTimeout)
+
+	// Requery video
+	v, err = app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
 
 	// Assert queue item was updated
 	q, err = app.Database.Client.Queue.Query().Where(queue.HasVodWith(vod.ID(v.ID))).Only(context.Background())
@@ -480,6 +500,11 @@ func TestArchiveClip(t *testing.T) {
 	// Wait for the video to be archived
 	tests_shared.WaitForArchiveCompletion(t, app, v.ID, TestArchiveTimeout)
 
+	// Requery video
+	v, err = app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
+
 	// Assert queue item was updated
 	q, err = app.Database.Client.Queue.Query().Where(queue.HasVodWith(vod.ID(v.ID))).Only(context.Background())
 	assert.NoError(t, err)
@@ -547,6 +572,11 @@ func TestArchiveVideoWithSpriteThumbnails(t *testing.T) {
 
 	// Wait for the video to be archived
 	tests_shared.WaitForArchiveCompletion(t, app, v.ID, TestArchiveTimeout)
+
+	// Requery video
+	v, err = app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
 
 	// Assert queue item was updated
 	q, err = app.Database.Client.Queue.Query().Where(queue.HasVodWith(vod.ID(v.ID))).Only(context.Background())

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -501,7 +501,7 @@ func TestArchiveClip(t *testing.T) {
 	tests_shared.WaitForArchiveCompletion(t, app, v.ID, TestArchiveTimeout)
 
 	// Requery video
-	v, err = app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
+	v, err = app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchClipId)).WithChapters().Only(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
 

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -80,7 +80,7 @@ func TestArchiveVideo(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Assert video was created
-	v, err := app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).Only(context.Background())
+	v, err := app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
 
@@ -156,6 +156,9 @@ func TestArchiveVideo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
 	assert.Len(t, v.SpriteThumbnailsImages, 1, "Sprite thumbnails should be generated for videos")
+
+	// Assert at least one chapter exists
+	assert.NotEmpty(t, v.Edges.Chapters, "Expected at least one chapter to be present")
 
 	// Test delete and ensure directory is removed
 	videoDirectory := filepath.Dir(filepath.Clean(v.VideoPath))
@@ -247,6 +250,9 @@ func TestArchiveVideoNoChat(t *testing.T) {
 	assert.NoFileExists(t, v.ChatPath)
 	assert.NoFileExists(t, v.ChatVideoPath)
 
+	// Assert at least one chapter exists
+	assert.NotEmpty(t, v.Edges.Chapters, "Expected at least one chapter to be present")
+
 	assert.NotEqual(t, 0, v.StorageSizeBytes)
 
 	// Assert video is playable
@@ -313,6 +319,9 @@ func TestArchiveVideoNoChatRender(t *testing.T) {
 	assert.FileExists(t, v.VideoPath)
 	assert.FileExists(t, v.ChatPath)
 	assert.NoFileExists(t, v.ChatVideoPath)
+
+	// Assert at least one chapter exists
+	assert.NotEmpty(t, v.Edges.Chapters, "Expected at least one chapter to be present")
 
 	assert.NotEqual(t, 0, v.StorageSizeBytes)
 
@@ -388,6 +397,9 @@ func TestArchiveVideoHLS(t *testing.T) {
 	assert.NoFileExists(t, v.ChatVideoPath)
 
 	assert.NotEqual(t, 0, v.StorageSizeBytes)
+
+	// Assert at least one chapter exists
+	assert.NotEmpty(t, v.Edges.Chapters, "Expected at least one chapter to be present")
 
 	// Assert video is playable
 	assert.True(t, tests_shared.IsPlayableVideo(v.VideoPath), "Video file is not playable")
@@ -557,6 +569,9 @@ func TestArchiveVideoWithSpriteThumbnails(t *testing.T) {
 	assert.NoFileExists(t, v.ChatVideoPath)
 
 	assert.NotEqual(t, 0, v.StorageSizeBytes)
+
+	// Assert at least one chapter exists
+	assert.NotEmpty(t, v.Edges.Chapters, "Expected at least one chapter to be present")
 
 	// Assert sprite thumbnail facts
 	v, err = app.Database.Client.Vod.Query().Where(vod.ID(v.ID)).Only(context.Background())

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -378,7 +378,7 @@ OUTER:
 
 				// Create initial chapter
 				_, err = s.ChapterService.CreateChapter(chapter.Chapter{
-					Type:  "GAME_CHANGE",
+					Type:  string(utils.ChapterTypeGameChange),
 					Start: 0,
 					End:   0,
 					Title: stream.GameName,
@@ -469,7 +469,7 @@ func (s *Service) updateLiveStreamArchiveChapter(stream platform.LiveStreamInfo)
 
 	// Create new chapter
 	_, err = s.ChapterService.CreateChapter(chapter.Chapter{
-		Type:  "GAME_CHANGE",
+		Type:  string(utils.ChapterTypeGameChange),
 		Start: lastChapter.End,
 		End:   0,
 		Title: stream.GameName,

--- a/internal/live/live_test.go
+++ b/internal/live/live_test.go
@@ -174,11 +174,8 @@ func assertVodAndQueue(t *testing.T, app *server.Application, liveChannel platfo
 	assert.True(t, tests_shared.IsPlayableVideo(vod.VideoPath), "Video file is not playable")
 	assert.True(t, tests_shared.IsPlayableVideo(vod.ChatVideoPath), "Video file is not playable")
 
-	// If live archive assert at least one chapter exists
-	if vod.Type == utils.Live {
-		assert.NoError(t, err, "Failed to get chapters for VOD")
-		assert.GreaterOrEqual(t, len(vod.Edges.Chapters), 1, "Expected at least one chapter for live archive VOD")
-	}
+	// Assert at least one chapter exists
+	assert.NotEmpty(t, vod.Edges.Chapters, "Expected at least one chapter to be present")
 }
 
 // TestTwitchWatchedChannelLive tests the basic live archiving of a Twitch channel

--- a/internal/platform/twitch.go
+++ b/internal/platform/twitch.go
@@ -93,6 +93,19 @@ func (c *TwitchConnection) GetVideo(ctx context.Context, id string, withChapters
 		}
 		chapters = append(chapters, convertedChapters...)
 		info.Chapters = chapters
+
+		// If chapter is empty use the category as a fallback chapter
+		if len(info.Chapters) == 0 {
+			info.Chapters = []chapter.Chapter{
+				{
+					ID:    "fallback",
+					Type:  string(utils.ChapterTypeFallback),
+					Title: gqlVideo.Game.Name,
+					Start: 0,
+					End:   int(info.Duration.Seconds()),
+				},
+			}
+		}
 	}
 
 	// get muted segments

--- a/internal/platform/twitch.go
+++ b/internal/platform/twitch.go
@@ -95,7 +95,7 @@ func (c *TwitchConnection) GetVideo(ctx context.Context, id string, withChapters
 		info.Chapters = chapters
 
 		// If chapter is empty use the category as a fallback chapter
-		if len(info.Chapters) == 0 {
+		if len(info.Chapters) == 0 && gqlVideo.Game.Name != "" {
 			info.Chapters = []chapter.Chapter{
 				{
 					ID:    "fallback",

--- a/internal/playlist/rule_test.go
+++ b/internal/playlist/rule_test.go
@@ -51,7 +51,7 @@ func setupAppAndSeed(t *testing.T) (*server.Application, *ent.Playlist, *ent.Cha
 
 	// Add chapters to the video
 	_, err = app.ChapterService.CreateChapter(chapter.Chapter{
-		Type:  "game_change",
+		Type:  string(utils.ChapterTypeGameChange),
 		Title: "Baldur's Gate 3",
 		Start: 0,
 		End:   3600,

--- a/internal/tasks/periodic/process.go
+++ b/internal/tasks/periodic/process.go
@@ -75,7 +75,7 @@ func (w SaveVideoChaptersWorker) Work(ctx context.Context, job *river.Job[SaveVi
 			}
 
 			if len(existingVideoChapters) == 0 {
-				log.Info().Str("video_id", fmt.Sprintf("%s", video.ID.String())).Msgf("saving chapters for external video %s", video.ExtID)
+				log.Info().Str("video_id", video.ID.String()).Msgf("saving chapters for external video %s", video.ExtID)
 
 				// save chapters to database
 				for _, c := range platformVideo.Chapters {
@@ -85,7 +85,7 @@ func (w SaveVideoChaptersWorker) Work(ctx context.Context, job *river.Job[SaveVi
 					}
 				}
 
-				log.Info().Str("video_id", fmt.Sprintf("%s", video.ID.String())).Str("chapters", fmt.Sprintf("%d", len(platformVideo.Chapters))).Msgf("saved chapters for video")
+				log.Info().Str("video_id", video.ID.String()).Str("chapters", fmt.Sprintf("%d", len(platformVideo.Chapters))).Msgf("saved chapters for video")
 			}
 		}
 

--- a/internal/tasks/periodic/process.go
+++ b/internal/tasks/periodic/process.go
@@ -61,7 +61,6 @@ func (w SaveVideoChaptersWorker) Work(ctx context.Context, job *river.Job[SaveVi
 			continue
 		}
 
-		log.Info().Msgf("saving chapters for video %s", video.ExtID)
 		platformVideo, err := platform.GetVideo(ctx, video.ExtID, true, true)
 		if err != nil {
 			return err
@@ -76,6 +75,7 @@ func (w SaveVideoChaptersWorker) Work(ctx context.Context, job *river.Job[SaveVi
 			}
 
 			if len(existingVideoChapters) == 0 {
+				log.Info().Str("video_id", fmt.Sprintf("%s", video.ID.String())).Msgf("saving chapters for external video %s", video.ExtID)
 
 				// save chapters to database
 				for _, c := range platformVideo.Chapters {
@@ -85,7 +85,7 @@ func (w SaveVideoChaptersWorker) Work(ctx context.Context, job *river.Job[SaveVi
 					}
 				}
 
-				log.Info().Str("video_id", fmt.Sprintf("%d", video.ID)).Str("chapters", fmt.Sprintf("%d", len(platformVideo.Chapters))).Msgf("saved chapters for video")
+				log.Info().Str("video_id", fmt.Sprintf("%s", video.ID.String())).Str("chapters", fmt.Sprintf("%d", len(platformVideo.Chapters))).Msgf("saved chapters for video")
 			}
 		}
 

--- a/internal/tasks/video.go
+++ b/internal/tasks/video.go
@@ -178,11 +178,9 @@ func (w PostProcessVideoWorker) Work(ctx context.Context, job *river.Job[PostPro
 		if err != nil {
 			return err
 		}
-		fmt.Println(videoChapters)
 
 		if len(videoChapters) > 0 {
 			for _, chapter := range videoChapters {
-				fmt.Println(chapter)
 				if chapter.End == 0 {
 					fmt.Println("updating chapter end time")
 					_, err = chapter.Update().SetEnd(duration).Save(ctx)

--- a/internal/utils/enum.go
+++ b/internal/utils/enum.go
@@ -219,3 +219,18 @@ func (PlaylistRuleField) Values() (kinds []string) {
 	}
 	return
 }
+
+// ChapterType represents the type of a chapter.
+type ChapterType string
+
+const (
+	ChapterTypeGameChange ChapterType = "GAME_CHANGE" // A chapter that indicates a change in the game being played
+	ChapterTypeFallback   ChapterType = "FALLBACK"    // A fallback chapter to be used when no other chapter is available, typically the video category/game is used instead
+)
+
+func (ChapterType) Values() (kinds []string) {
+	for _, s := range []ChapterType{ChapterTypeGameChange, ChapterTypeFallback} {
+		kinds = append(kinds, string(s))
+	}
+	return
+}


### PR DESCRIPTION
https://github.com/Zibbp/ganymede/issues/865
A video can have no chapters but usually has a category/game. If no chapters are returned from the platform API then use the video category/game as the only chapter. 

This can be backfilled by running the "Save Chapters for Videos", assuming the videos are still on Twitch.