### PR TITLE
fix(multistream): synced player kept resyncing when not needed

### DIFF
--- a/frontend/app/components/videos/multistream/SyncedVideoPlayer.tsx
+++ b/frontend/app/components/videos/multistream/SyncedVideoPlayer.tsx
@@ -34,7 +34,7 @@ const SyncedVideoPlayer = ({ src, vodId, title, poster, time, playing, muted }: 
         await currentPlayer.pause();
       }
     })();
-  }, [playing, canPlay, time])
+  }, [playing, canPlay /* `time` should not be part of dependencies, it already has its own effect */])
 
   useEffect(() => {
     if (!player.current) return;


### PR DESCRIPTION
During v4, `time` was added as a dependency for the `useEffect` dedicated to controlling the play/pause, causing the player to try to sync again then play every second.

The `time` already has its own `useEffect` for the time sync with a small time margin to prevent the constant resync every second (because seeking is not always very exact).