### PR TITLE
feat: supervisord exit logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,6 +197,8 @@ ENV HOSTNAME="0.0.0.0"
 # Setup entrypoint
 COPY entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh
+COPY bin/supervisord-exit-on-fatal.sh /usr/local/bin/supervisord-exit-on-fatal.sh
+RUN chmod +x /usr/local/bin/supervisord-exit-on-fatal.sh
 COPY supervisord.conf /opt/app/supervisord.conf
 
 EXPOSE 4000

--- a/bin/supervisord-exit-on-fatal.sh
+++ b/bin/supervisord-exit-on-fatal.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Exit supervisord if any program reaches FATAL state
+# This allows Docker or other orchestration to restart the container
+# after a fatal error occurs.
+set -eu
+
+SUPERV_PIDFILE=${SUPERV_PIDFILE:-/var/run/supervisord.pid}
+SUPERV_CONF=${SUPERV_CONF:-/opt/app/supervisord.conf}
+
+while :; do
+  printf "READY\n"
+
+  IFS= read -r HEADER || exit 0
+  LEN=$(printf "%s" "$HEADER" | awk -F'len:' '{print $2+0}')
+  if [ "${LEN:-0}" -gt 0 ]; then dd bs=1 count="$LEN" >/dev/null 2>&1; fi
+
+  printf "RESULT 2\nOK"
+
+  echo "[exit_on_failure] Fatal detected — attempting shutdown" >&2
+
+  # Attempt to gracefully shutdown supervisord in several ways
+  if command -v supervisorctl >/dev/null 2>&1; then
+    supervisorctl -c "$SUPERV_CONF" shutdown >/dev/null 2>&1 || true
+  fi
+
+  # SIGTERM/SIGKILL supervisord if still running
+  if [ -f "$SUPERV_PIDFILE" ]; then
+    PID="$(cat "$SUPERV_PIDFILE" 2>/dev/null || echo "")"
+    if [ -n "${PID}" ] && [ -d "/proc/$PID" ]; then
+      echo "[exit_on_failure] SIGTERM supervisord pid=$PID" >&2
+      kill -TERM "$PID" 2>/dev/null || true
+      # wait briefly, then SIGKILL if still alive
+      for i in 1 2 3; do
+        [ ! -d "/proc/$PID" ] && break
+        sleep 0.2
+      done
+      if [ -d "/proc/$PID" ]; then
+        echo "[exit_on_failure] SIGKILL supervisord pid=$PID" >&2
+        kill -KILL "$PID" 2>/dev/null || true
+      fi
+    fi
+  fi
+
+  # Fallback: kill parent process if still running
+  PPID="$(awk '/PPid:/{print $2}' /proc/$$/status 2>/dev/null || echo "")"
+  if [ -n "$PPID" ] && [ -d "/proc/$PPID" ]; then
+    echo "[exit_on_failure] fallback SIGTERM ppid=$PPID" >&2
+    kill -TERM "$PPID" 2>/dev/null || true
+  fi
+
+  sleep 0.2
+  exit 0
+done

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,7 +1,17 @@
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
 [supervisord]
 nodaemon=true
 logfile=/var/log/supervisord.log
 pidfile=/var/run/supervisord.pid
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
 
 [program:api]
 command=gosu abc /opt/app/ganymede-api
@@ -30,3 +40,14 @@ stderr_logfile=/dev/stderr
 stdout_logfile=/dev/stdout
 stderr_logfile_maxbytes=0
 stdout_logfile_maxbytes=0
+
+; ===== Exit Supervisord (to stop container) if any program reaches FATAL =====
+; ===== Docker or other orchestration can then restart the container =====
+[eventlistener:exit_on_failure]
+command=/usr/local/bin/supervisord-exit-on-fatal.sh
+events=PROCESS_STATE_FATAL
+autorestart=false
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
https://github.com/Zibbp/ganymede/issues/887
If any supervisord program fatally stops (e.g. stops trying to start) then it sits in limbo as the other programs are still running. This change will stop the main supervisord PID if *any* program fatally exists. This allows Docker to restart the container and start the whole process over again.

```
ganymede  | {"level":"fatal","error":"querying server version dial tcp: lookup ganymede-db on 127.0.0.11:53: server misbehaving","time":"2025-10-12T10:25:35-05:00","message":"error running auto migration"}
ganymede  | {"level":"fatal","error":"querying server version dial tcp: lookup ganymede-db on 127.0.0.11:53: server misbehaving","time":"2025-10-12T10:25:35-05:00","message":"error running auto migration"}
ganymede  | 2025-10-12 10:25:35,461 WARN exited: worker (exit status 1; not expected)
ganymede  | 2025-10-12 10:25:35,461 INFO gave up: worker entered FATAL state, too many start retries too quickly
ganymede  | 2025-10-12 10:25:35,461 WARN exited: api (exit status 1; not expected)
ganymede  | 2025-10-12 10:25:36,462 INFO gave up: api entered FATAL state, too many start retries too quickly
ganymede  | RESULT 2
ganymede  | [exit_on_failure] Fatal detected ΓÇö attempting shutdown
ganymede  | [exit_on_failure] SIGTERM supervisord pid=28
ganymede  | OK2025-10-12 10:25:36,632 WARN received SIGTERM indicating exit request
ganymede  | 2025-10-12 10:25:36,632 INFO waiting for exit_on_failure, frontend to die
ganymede  | /usr/local/bin/entrypoint.sh: line 37:    28 Killed                  /usr/bin/supervisord -c /opt/app/supervisord.conf
ganymede exited with code 0
```

