### PR TITLE
fix: quality selector

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -237,10 +237,7 @@ func DownloadTwitchLiveVideo(ctx context.Context, video ent.Vod, channel ent.Cha
 	closestQuality := utils.SelectClosestQuality(video.Resolution, qualities)
 	log.Info().Str("requested_quality", video.Resolution).Msgf("selected closest quality %s", closestQuality)
 
-	switch closestQuality {
-	case "best":
-		closestQuality = "chunked"
-	case "audio":
+	if closestQuality == "audio" {
 		closestQuality = "audio_only"
 	}
 

--- a/internal/utils/video.go
+++ b/internal/utils/video.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"math"
 	"regexp"
 	"sort"
 	"strconv"
@@ -22,6 +23,10 @@ func parseQuality(q string) Quality {
 
 	// If it doesn’t look like "123p" or "123p45", see if it's just digits:
 	if len(matches) == 0 {
+		if q == "chunked" {
+			return Quality{Resolution: math.MaxInt, FPS: 60, Original: q}
+		}
+
 		if num, err := strconv.Atoi(q); err == nil {
 			// Treat "720" as Resolution=720, FPS=60 (default)
 			return Quality{Resolution: num, FPS: 60, Original: q}

--- a/internal/utils/video_test.go
+++ b/internal/utils/video_test.go
@@ -13,13 +13,15 @@ func TestSelectClosestQuality(t *testing.T) {
 		expected string
 	}{
 		{"best", []string{"chunked", "1080p60", "360p30", "480p30", "720p60", "audio_only"}, "chunked"},
+		{"1440p", []string{"chunked", "360p30", "480p30", "720p60", "audio_only"}, "chunked"},
+		{"1080p", []string{"chunked", "360p30", "480p30", "720p60", "audio_only"}, "chunked"},
 		{"1080p", []string{"chunked", "1080p60", "360p30", "480p30", "720p60", "audio_only"}, "1080p60"},
 		{"1080p60", []string{"chunked", "1080p60", "360p30", "480p30", "720p60", "audio_only"}, "1080p60"},
 		{"1080p30", []string{"chunked", "1080p60", "360p30", "480p30", "720p60", "audio_only"}, "1080p60"},
 		{"720p", []string{"chunked", "1080p60", "360p30", "480p30", "720p60", "audio_only"}, "720p60"},
 		{"best", []string{"chunked", "1080p60", "360p30", "480p30", "720p60", "audio_only"}, "chunked"},
 		{"audio_only", []string{"chunked", "1080p60", "360p30", "480p30", "720p60", "audio_only"}, "audio_only"},
-		{"500p", []string{"chunked", "1080p60", "360p30", "480p30", "720p60", "audio_only"}, "1080p60"},
+		{"500p", []string{"chunked", "1080p60", "360p30", "480p30", "720p60", "audio_only"}, "chunked"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
I tested the new quality selector and found edge case.
If the quality is 1440p or 1080p and stream is only 1080p, it would select 720p.