### PR TITLE
feat(channel): conditionally replace profile image during periodic sync

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -81,7 +81,7 @@ func (s *Service) ArchiveChannel(ctx context.Context, channelName string) (*ent.
 	}
 
 	// Download channel profile image
-	err = utils.DownloadFile(platformChannel.ProfileImageURL, fmt.Sprintf("%s/%s/%s", env.VideosDir, channelFolderName, "profile.png"))
+	err = utils.DownloadFile(ctx, platformChannel.ProfileImageURL, fmt.Sprintf("%s/%s/%s", env.VideosDir, channelFolderName, "profile.png"))
 	if err != nil {
 		log.Error().Err(err).Msg("error downloading channel profile image")
 	}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/uuid"
@@ -81,7 +82,7 @@ func (s *Service) ArchiveChannel(ctx context.Context, channelName string) (*ent.
 	}
 
 	// Download channel profile image
-	err = utils.DownloadFile(ctx, platformChannel.ProfileImageURL, fmt.Sprintf("%s/%s/%s", env.VideosDir, channelFolderName, "profile.png"))
+	err = utils.DownloadFile(ctx, platformChannel.ProfileImageURL, filepath.Join(env.VideosDir, channelFolderName, "profile.png"))
 	if err != nil {
 		log.Error().Err(err).Msg("error downloading channel profile image")
 	}
@@ -91,7 +92,7 @@ func (s *Service) ArchiveChannel(ctx context.Context, channelName string) (*ent.
 		ExtID:       platformChannel.ID,
 		Name:        platformChannel.Login,
 		DisplayName: platformChannel.DisplayName,
-		ImagePath:   fmt.Sprintf("%s/%s/profile.png", env.VideosDir, channelFolderName),
+		ImagePath:   filepath.Join(env.VideosDir, channelFolderName, "profile.png"),
 	}
 
 	dbC, err := s.ChannelService.CreateChannel(channelDTO)

--- a/internal/channel/channel.go
+++ b/internal/channel/channel.go
@@ -211,15 +211,21 @@ func (s *Service) UpdateChannelImage(ctx context.Context, channelID uuid.UUID, c
 	}
 
 	// Download channel profile image
+	imagePath := fmt.Sprintf("%s/%s/%s", env.VideosDir, channelFolderName, "profile.png")
 	if checkIfExists {
-		exists := utils.FileExists(fmt.Sprintf("%s/%s/%s", env.VideosDir, channelFolderName, "profile.png"))
-		if exists {
-			log.Debug().Msgf("channel profile image already exists for channel: %s", twitchChannel.Login)
-			return nil
+		changed, err := utils.DownloadFileIfChanged(twitchChannel.ProfileImageURL, imagePath)
+		if err != nil {
+			return fmt.Errorf("error downloading channel profile image: %v", err)
 		}
+		if !changed {
+			log.Debug().Msgf("channel profile image unchanged for channel: %s", twitchChannel.Login)
+		} else {
+			log.Debug().Msgf("channel profile image updated for channel: %s", twitchChannel.Login)
+		}
+		return nil
 	}
 
-	err = utils.DownloadFile(twitchChannel.ProfileImageURL, fmt.Sprintf("%s/%s/%s", env.VideosDir, channelFolderName, "profile.png"))
+	err = utils.DownloadFile(twitchChannel.ProfileImageURL, imagePath)
 	if err != nil {
 		return fmt.Errorf("error downloading channel profile image: %v", err)
 	}

--- a/internal/channel/channel.go
+++ b/internal/channel/channel.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zibbp/ganymede/internal/platform"
 	"github.com/zibbp/ganymede/internal/storagetemplate"
 	"github.com/zibbp/ganymede/internal/utils"
+	"path/filepath"
 )
 
 type Service struct {
@@ -211,9 +212,9 @@ func (s *Service) UpdateChannelImage(ctx context.Context, channelID uuid.UUID, c
 	}
 
 	// Download channel profile image
-	imagePath := fmt.Sprintf("%s/%s/%s", env.VideosDir, channelFolderName, "profile.png")
+	imagePath := filepath.Join(env.VideosDir, channelFolderName, "profile.png")
 	if checkIfExists {
-		changed, err := utils.DownloadFileIfChanged(twitchChannel.ProfileImageURL, imagePath)
+		changed, err := utils.DownloadFileIfChanged(ctx, twitchChannel.ProfileImageURL, imagePath)
 		if err != nil {
 			return fmt.Errorf("error downloading channel profile image: %v", err)
 		}
@@ -225,7 +226,7 @@ func (s *Service) UpdateChannelImage(ctx context.Context, channelID uuid.UUID, c
 		return nil
 	}
 
-	err = utils.DownloadFile(twitchChannel.ProfileImageURL, imagePath)
+	err = utils.DownloadFile(ctx, twitchChannel.ProfileImageURL, imagePath)
 	if err != nil {
 		return fmt.Errorf("error downloading channel profile image: %v", err)
 	}

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -126,7 +126,9 @@ func writeIfDifferent(path string, data []byte) (bool, error) {
 	// Atomically rename to the final path
 	err = os.Rename(tmpPath, path)
 	if err != nil {
-		os.Remove(tmpPath) // Cleanup on failure
+		if removeErr := os.Remove(tmpPath); removeErr != nil {
+			log.Debug().Err(removeErr).Msg("error removing temporary file after rename failure")
+		}
 		return false, fmt.Errorf("error renaming temporary file: %v", err)
 	}
 

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -108,11 +108,14 @@ func fetchURL(ctx context.Context, url string) ([]byte, error) {
 }
 
 func writeIfDifferent(path string, data []byte) (bool, error) {
-	if FileExists(path) {
+	// Preserve existing file permissions, default to 0644
+	mode := os.FileMode(0644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode()
+		// Compare contents to skip unnecessary writes
 		existingContent, err := os.ReadFile(path)
 		if err == nil {
 			if bytes.Equal(existingContent, data) {
-				// Files are the same, no need to overwrite
 				return false, nil
 			}
 		} else {
@@ -120,18 +123,45 @@ func writeIfDifferent(path string, data []byte) (bool, error) {
 		}
 	}
 
-	tmpPath := path + ".tmp"
-	err := os.WriteFile(tmpPath, data, 0644)
+	// Create a unique temp file in the same directory for atomic rename
+	dir := filepath.Dir(path)
+	tmpFile, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
 	if err != nil {
+		return false, fmt.Errorf("error creating temporary file: %v", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	// Ensure cleanup on any error
+	defer func() {
+		// If we haven't renamed yet (i.e. tmpPath still exists after an error),
+		// clean up. After a successful rename this Remove is a harmless no-op error.
+		if removeErr := os.Remove(tmpPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			log.Debug().Err(removeErr).Msg("error removing temporary file")
+		}
+	}()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
 		return false, fmt.Errorf("error writing temporary file: %v", err)
 	}
 
+	// Flush to disk before rename
+	if err := tmpFile.Sync(); err != nil {
+		tmpFile.Close()
+		return false, fmt.Errorf("error syncing temporary file: %v", err)
+	}
+
+	if err := tmpFile.Chmod(mode); err != nil {
+		tmpFile.Close()
+		return false, fmt.Errorf("error setting file permissions: %v", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return false, fmt.Errorf("error closing temporary file: %v", err)
+	}
+
 	// Atomically rename to the final path
-	err = os.Rename(tmpPath, path)
-	if err != nil {
-		if removeErr := os.Remove(tmpPath); removeErr != nil {
-			log.Debug().Err(removeErr).Msg("error removing temporary file after rename failure")
-		}
+	if err := os.Rename(tmpPath, path); err != nil {
 		return false, fmt.Errorf("error renaming temporary file: %v", err)
 	}
 

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -95,10 +95,13 @@ func fetchURL(ctx context.Context, url string) ([]byte, error) {
 		return nil, fmt.Errorf("error downloading file: %v", resp.Status)
 	}
 
-	// Limit to 5MB to prevent huge memory usage
-	content, err := io.ReadAll(io.LimitReader(resp.Body, maxDownloadSizeBytes))
+	// Read up to maxDownloadSizeBytes+1 to detect overflow
+	content, err := io.ReadAll(io.LimitReader(resp.Body, maxDownloadSizeBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %v", err)
+	}
+	if int64(len(content)) > maxDownloadSizeBytes {
+		return nil, fmt.Errorf("response exceeded maximum download size of %d bytes", maxDownloadSizeBytes)
 	}
 
 	return content, nil

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -73,67 +73,42 @@ func DownloadAndSaveFile(url, path string) error {
 	return nil
 }
 
-// DownloadFile downloads file from url to the path provided
-func DownloadFile(url, path string) error {
-	log.Debug().Msgf("downloading file: %s", url)
-	// Get response bytes from URL
-	resp, err := http.Get(url)
+const maxDownloadSizeBytes = 5 * 1024 * 1024 // 5 MB limit for profile images and small downloads
+
+func fetchURL(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return fmt.Errorf("error downloading file: %v", err)
+		return nil, fmt.Errorf("error creating request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error downloading file: %v", err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
 			log.Debug().Err(err).Msg("error closing response body")
 		}
 	}()
+
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("error downloading file: %v", resp)
+		return nil, fmt.Errorf("error downloading file: %v", resp.Status)
 	}
 
-	// Create file
-	file, err := os.Create(path)
+	// Limit to 5MB to prevent huge memory usage
+	content, err := io.ReadAll(io.LimitReader(resp.Body, maxDownloadSizeBytes))
 	if err != nil {
-		return fmt.Errorf("error creating file: %v", err)
+		return nil, fmt.Errorf("error reading response body: %v", err)
 	}
-	defer func() {
-		if err := file.Close(); err != nil {
-			log.Debug().Err(err).Msg("error closing file")
-		}
-	}()
 
-	// Write bytes to file
-	_, err = io.Copy(file, resp.Body)
-	if err != nil {
-		return fmt.Errorf("error writing file: %v", err)
-	}
-	return nil
+	return content, nil
 }
 
-// DownloadFileIfChanged downloads file from url to the path provided only if the content is different
-func DownloadFileIfChanged(url, path string) (bool, error) {
-	log.Debug().Msgf("downloading file to check for changes: %s", url)
-	resp, err := http.Get(url)
-	if err != nil {
-		return false, fmt.Errorf("error downloading file: %v", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Debug().Err(err).Msg("error closing response body")
-		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		return false, fmt.Errorf("error downloading file: %v", resp)
-	}
-
-	newContent, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return false, fmt.Errorf("error reading response body: %v", err)
-	}
-
+func writeIfDifferent(path string, data []byte) (bool, error) {
 	if FileExists(path) {
 		existingContent, err := os.ReadFile(path)
 		if err == nil {
-			if bytes.Equal(existingContent, newContent) {
+			if bytes.Equal(existingContent, data) {
 				// Files are the same, no need to overwrite
 				return false, nil
 			}
@@ -142,12 +117,41 @@ func DownloadFileIfChanged(url, path string) (bool, error) {
 		}
 	}
 
-	err = os.WriteFile(path, newContent, 0644)
+	tmpPath := path + ".tmp"
+	err := os.WriteFile(tmpPath, data, 0644)
 	if err != nil {
-		return false, fmt.Errorf("error writing file: %v", err)
+		return false, fmt.Errorf("error writing temporary file: %v", err)
+	}
+
+	// Atomically rename to the final path
+	err = os.Rename(tmpPath, path)
+	if err != nil {
+		os.Remove(tmpPath) // Cleanup on failure
+		return false, fmt.Errorf("error renaming temporary file: %v", err)
 	}
 
 	return true, nil
+}
+
+// DownloadFile downloads file from url to the path provided
+func DownloadFile(ctx context.Context, url, path string) error {
+	log.Debug().Msgf("downloading file: %s", url)
+	data, err := fetchURL(ctx, url)
+	if err != nil {
+		return err
+	}
+	_, err = writeIfDifferent(path, data)
+	return err
+}
+
+// DownloadFileIfChanged downloads file from url to the path provided only if the content is different
+func DownloadFileIfChanged(ctx context.Context, url, path string) (bool, error) {
+	log.Debug().Msgf("downloading file to check for changes: %s", url)
+	data, err := fetchURL(ctx, url)
+	if err != nil {
+		return false, err
+	}
+	return writeIfDifferent(path, data)
 }
 
 func WriteJsonFile(j interface{}, path string) error {

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -106,6 +107,47 @@ func DownloadFile(url, path string) error {
 		return fmt.Errorf("error writing file: %v", err)
 	}
 	return nil
+}
+
+// DownloadFileIfChanged downloads file from url to the path provided only if the content is different
+func DownloadFileIfChanged(url, path string) (bool, error) {
+	log.Debug().Msgf("downloading file to check for changes: %s", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return false, fmt.Errorf("error downloading file: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Debug().Err(err).Msg("error closing response body")
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("error downloading file: %v", resp)
+	}
+
+	newContent, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("error reading response body: %v", err)
+	}
+
+	if FileExists(path) {
+		existingContent, err := os.ReadFile(path)
+		if err == nil {
+			if bytes.Equal(existingContent, newContent) {
+				// Files are the same, no need to overwrite
+				return false, nil
+			}
+		} else {
+			log.Debug().Err(err).Msg("error reading existing file, proceeding to overwrite")
+		}
+	}
+
+	err = os.WriteFile(path, newContent, 0644)
+	if err != nil {
+		return false, fmt.Errorf("error writing file: %v", err)
+	}
+
+	return true, nil
 }
 
 func WriteJsonFile(j interface{}, path string) error {

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -141,18 +141,24 @@ func writeIfDifferent(path string, data []byte) (bool, error) {
 	}()
 
 	if _, err := tmpFile.Write(data); err != nil {
-		tmpFile.Close()
+		if closeErr := tmpFile.Close(); closeErr != nil {
+			log.Debug().Err(closeErr).Msg("error closing temporary file after write failure")
+		}
 		return false, fmt.Errorf("error writing temporary file: %v", err)
 	}
 
 	// Flush to disk before rename
 	if err := tmpFile.Sync(); err != nil {
-		tmpFile.Close()
+		if closeErr := tmpFile.Close(); closeErr != nil {
+			log.Debug().Err(closeErr).Msg("error closing temporary file after sync failure")
+		}
 		return false, fmt.Errorf("error syncing temporary file: %v", err)
 	}
 
 	if err := tmpFile.Chmod(mode); err != nil {
-		tmpFile.Close()
+		if closeErr := tmpFile.Close(); closeErr != nil {
+			log.Debug().Err(closeErr).Msg("error closing temporary file after chmod failure")
+		}
 		return false, fmt.Errorf("error setting file permissions: %v", err)
 	}
 


### PR DESCRIPTION
## Description
This PR updates the periodic channel sync task to intelligently update profile images if they have changed on the platform, and refactors the underlying file download utilities for safety and maintainability.

Previously, the background sync task would entirely skip downloading a profile image if a local file already existed, which resulted in outdated avatars whenever a streamer updated their profile picture.

## Changes Made

### Feature
* **`internal/channel/channel.go`**: Updated `UpdateChannelImage` to compare remote and local profile images during periodic syncs, replacing the file only when it has actually changed.

### Refactoring (`internal/utils/file.go`)
* Extracted shared `fetchURL` and `writeIfDifferent` helpers to deduplicate logic between `DownloadFile` and `DownloadFileIfChanged`.
* **Context support** — HTTP requests use `http.NewRequestWithContext` to respect cancellation and prevent hanging periodic syncs.
* **Memory bounds** — Response bodies are capped at 5 MB via `io.LimitReader`, with an explicit overflow check that returns a clear error instead of silently truncating.
* **Atomic writes** — Uses `os.CreateTemp` for unique temp files (no race conditions), `fsync` for durability, and `os.Rename` for atomicity. Existing file permissions are preserved.

### Path consistency (`internal/channel/channel.go`, `internal/archive/archive.go`)
* Replaced `fmt.Sprintf` path construction with `filepath.Join` for platform-safe, normalized paths.
* Updated all `DownloadFile` callers to pass `context.Context`.
