### PR TITLE
feat(frontend): add absolute clock time display to video player

### DIFF
--- a/frontend/app/components/videos/Player.module.css
+++ b/frontend/app/components/videos/Player.module.css
@@ -26,3 +26,22 @@
 .mediaPlayerPoster {
   object-fit: contain;
 }
+
+.absoluteTimeOverlay {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  background: rgba(0, 0, 0, 0.7);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  color: white;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.absoluteTimeText {
+  font-family: var(--mantine-font-family-monospace);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+

--- a/frontend/app/components/videos/Player.tsx
+++ b/frontend/app/components/videos/Player.tsx
@@ -1,11 +1,12 @@
 import '@vidstack/react/player/styles/default/theme.css';
 import '@vidstack/react/player/styles/default/layouts/video.css';
-import { MediaPlayer, MediaPlayerInstance, MediaProvider, MediaSrc, Poster, Track, VideoMimeType } from '@vidstack/react';
+import { MediaPlayer, MediaPlayerInstance, MediaProvider, MediaSrc, Poster, Track, VideoMimeType, useMediaStore } from '@vidstack/react';
 import { defaultLayoutIcons, DefaultVideoLayout } from '@vidstack/react/player/layouts/default';
 import { Video, VideoType } from '@/app/hooks/useVideos';
 import classes from "./Player.module.css"
 import { RefObject, useEffect, useRef, useState } from 'react';
 import { env } from 'next-runtime-env';
+import dayjs from 'dayjs';
 import { escapeURL } from '@/app/util/util';
 import { PlaybackStatus, useFetchPlaybackForVideo, useSetPlaybackProgressForVideo, useStartPlaybackForVideo, useUpdatePlaybackProgressForVideo } from '@/app/hooks/usePlayback';
 import { useAxiosPrivate } from '@/app/hooks/useAxios';
@@ -21,6 +22,17 @@ interface Params {
   video: Video;
   ref: RefObject<MediaPlayerInstance | null>;
 }
+
+const AbsoluteTimeDisplay = ({ streamedAt }: { streamedAt: string | Date }) => {
+  const { currentTime } = useMediaStore();
+  const absoluteTime = dayjs(streamedAt).add(currentTime, 'second');
+
+  return (
+    <div className={classes.absoluteTimeOverlay}>
+      <span className={classes.absoluteTimeText}>{absoluteTime.format('YYYY-MM-DD HH:mm:ss')}</span>
+    </div>
+  );
+};
 
 const VideoPlayer = ({ video, ref }: Params) => {
   const searchParams = useSearchParams()
@@ -39,6 +51,7 @@ const VideoPlayer = ({ video, ref }: Params) => {
   const setPlaybackProgressMutation = useSetPlaybackProgressForVideo()
 
   const videoTheaterMode = useSettingsStore((state) => state.videoTheaterMode);
+  const showAbsoluteTime = useSettingsStore((state) => state.showAbsoluteTime);
 
   const axiosPrivate = useAxiosPrivate();
   // get playback data
@@ -190,6 +203,7 @@ const VideoPlayer = ({ video, ref }: Params) => {
       posterLoad="eager"
       volume={playerVolume}
     >
+      {showAbsoluteTime && <AbsoluteTimeDisplay streamedAt={video.streamed_at} />}
       <MediaProvider>
         <Poster className={`${classes.mediaPlayerPoster} vds-poster`} src={videoPoster} alt={video.title} />
         {!video.processing && (

--- a/frontend/app/components/videos/Player.tsx
+++ b/frontend/app/components/videos/Player.tsx
@@ -15,6 +15,7 @@ import VideoEventBus from '@/app/util/VideoEventBus';
 import VideoPlayerTheaterModeIcon from './PlayerTheaterModeIcon';
 import useSettingsStore from '@/app/store/useSettingsStore';
 import VideoPlayerHideChatIcon from './PlayerHideChatIcon';
+import VideoPlayerAbsoluteTimeIcon from './PlayerAbsoluteTimeIcon';
 
 interface Params {
   video: Video;
@@ -202,7 +203,12 @@ const VideoPlayer = ({ video, ref }: Params) => {
       <DefaultVideoLayout icons={defaultLayoutIcons} noScrubGesture={false}
         slots={{
           beforeFullscreenButton: <VideoPlayerTheaterModeIcon />,
-          afterFullscreenButton: <VideoPlayerHideChatIcon />
+          afterFullscreenButton: (
+            <>
+              <VideoPlayerAbsoluteTimeIcon />
+              <VideoPlayerHideChatIcon />
+            </>
+          )
         }}
         thumbnails={thumbnails}
       />

--- a/frontend/app/components/videos/Player.tsx
+++ b/frontend/app/components/videos/Player.tsx
@@ -1,10 +1,10 @@
 import '@vidstack/react/player/styles/default/theme.css';
 import '@vidstack/react/player/styles/default/layouts/video.css';
-import { MediaPlayer, MediaPlayerInstance, MediaProvider, MediaSrc, Poster, Track, VideoMimeType, useMediaStore } from '@vidstack/react';
+import { MediaPlayer, MediaPlayerInstance, MediaProvider, MediaSrc, Poster, Track, VideoMimeType, useMediaState } from '@vidstack/react';
 import { defaultLayoutIcons, DefaultVideoLayout } from '@vidstack/react/player/layouts/default';
 import { Video, VideoType } from '@/app/hooks/useVideos';
 import classes from "./Player.module.css"
-import { RefObject, useEffect, useRef, useState } from 'react';
+import { RefObject, useEffect, useMemo, useRef, useState } from 'react';
 import { env } from 'next-runtime-env';
 import dayjs from 'dayjs';
 import { escapeURL } from '@/app/util/util';
@@ -24,8 +24,12 @@ interface Params {
 }
 
 const AbsoluteTimeDisplay = ({ streamedAt }: { streamedAt: string | Date }) => {
-  const { currentTime } = useMediaStore();
-  const absoluteTime = dayjs(streamedAt).add(currentTime, 'second');
+  const currentTime = useMediaState('currentTime');
+  const flooredCurrentTime = Math.floor(currentTime);
+  const absoluteTime = useMemo(
+    () => dayjs(streamedAt).add(flooredCurrentTime, 'second'),
+    [streamedAt, flooredCurrentTime],
+  );
 
   return (
     <div className={classes.absoluteTimeOverlay}>

--- a/frontend/app/components/videos/PlayerAbsoluteTimeIcon.module.css
+++ b/frontend/app/components/videos/PlayerAbsoluteTimeIcon.module.css
@@ -3,7 +3,7 @@
   color: #f5f5f5;
   transition: all 0.2s ease-in-out;
 }
-.customFullScreenButton {
+.absoluteTimeButton {
   color: #f5f5f5;
 
   &:hover {

--- a/frontend/app/components/videos/PlayerAbsoluteTimeIcon.module.css
+++ b/frontend/app/components/videos/PlayerAbsoluteTimeIcon.module.css
@@ -1,0 +1,13 @@
+.absoluteTimeIcon {
+  cursor: pointer;
+  color: #f5f5f5;
+  transition: all 0.2s ease-in-out;
+}
+.customFullScreenButton {
+  color: #f5f5f5;
+
+  &:hover {
+    color: #f5f5f5;
+    background-color: rgb(255 255 255 / 0.2);
+  }
+}

--- a/frontend/app/components/videos/PlayerAbsoluteTimeIcon.tsx
+++ b/frontend/app/components/videos/PlayerAbsoluteTimeIcon.tsx
@@ -19,7 +19,6 @@ const VideoPlayerAbsoluteTimeIcon = () => {
           size="xl"
           variant="transparent"
           onClick={toggleAbsoluteTime}
-          onTouchStart={toggleAbsoluteTime}
           className={classes.customFullScreenButton}
         >
           <IconClock size="1.7rem" />

--- a/frontend/app/components/videos/PlayerAbsoluteTimeIcon.tsx
+++ b/frontend/app/components/videos/PlayerAbsoluteTimeIcon.tsx
@@ -19,7 +19,7 @@ const VideoPlayerAbsoluteTimeIcon = () => {
           size="xl"
           variant="transparent"
           onClick={toggleAbsoluteTime}
-          className={classes.customFullScreenButton}
+          className={classes.absoluteTimeButton}
         >
           <IconClock size="1.7rem" />
         </ActionIcon>

--- a/frontend/app/components/videos/PlayerAbsoluteTimeIcon.tsx
+++ b/frontend/app/components/videos/PlayerAbsoluteTimeIcon.tsx
@@ -1,0 +1,32 @@
+import { ActionIcon, Tooltip } from "@mantine/core";
+import { IconClock } from "@tabler/icons-react";
+import classes from "./PlayerAbsoluteTimeIcon.module.css"
+import useSettingsStore from "@/app/store/useSettingsStore";
+import { useTranslations } from "next-intl";
+
+const VideoPlayerAbsoluteTimeIcon = () => {
+  const t = useTranslations("VideoComponents")
+  const { setShowAbsoluteTime } = useSettingsStore()
+  const showAbsoluteTime = useSettingsStore((state) => state.showAbsoluteTime);
+
+  const toggleAbsoluteTime = () => {
+    setShowAbsoluteTime(!showAbsoluteTime);
+  };
+  return (
+    <div className={classes.absoluteTimeIcon}>
+      <Tooltip label={t('absoluteTimeIconTooltip')} position="bottom">
+        <ActionIcon
+          size="xl"
+          variant="transparent"
+          onClick={toggleAbsoluteTime}
+          onTouchStart={toggleAbsoluteTime}
+          className={classes.customFullScreenButton}
+        >
+          <IconClock size="1.7rem" />
+        </ActionIcon>
+      </Tooltip>
+    </div>
+  );
+}
+
+export default VideoPlayerAbsoluteTimeIcon;

--- a/frontend/app/components/videos/PlayerAbsoluteTimeIcon.tsx
+++ b/frontend/app/components/videos/PlayerAbsoluteTimeIcon.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "next-intl";
 
 const VideoPlayerAbsoluteTimeIcon = () => {
   const t = useTranslations("VideoComponents")
-  const { setShowAbsoluteTime } = useSettingsStore()
+  const setShowAbsoluteTime = useSettingsStore((state) => state.setShowAbsoluteTime);
   const showAbsoluteTime = useSettingsStore((state) => state.showAbsoluteTime);
 
   const toggleAbsoluteTime = () => {

--- a/frontend/app/store/useSettingsStore.ts
+++ b/frontend/app/store/useSettingsStore.ts
@@ -9,6 +9,7 @@ interface SettingsState {
   hideChat: boolean;
   showChatHistogram: boolean;
   showProcessingVideosInRecentlyArchived: boolean;
+  showAbsoluteTime: boolean;
   setVideoLimit: (limit: number) => void;
   setAdminItemsPerPage: (limit: number) => void;
   setChatPlaybackSmoothScroll: (smooth: boolean) => void;
@@ -16,6 +17,7 @@ interface SettingsState {
   setHideChat: (hide: boolean) => void;
   setShowChatHistogram: (show: boolean) => void;
   setShowProcessingVideosInRecentlyArchived: (show: boolean) => void;
+  setShowAbsoluteTime: (show: boolean) => void;
 }
 
 // Create the store with persist middleware
@@ -30,6 +32,7 @@ const useSettingsStore = create<SettingsState>()(
       hideChat: false,
       showChatHistogram: true,
       showProcessingVideosInRecentlyArchived: true,
+      showAbsoluteTime: false,
 
       setVideoLimit: (limit: number) => set({ videoLimit: limit }),
 
@@ -48,6 +51,8 @@ const useSettingsStore = create<SettingsState>()(
 
       setShowProcessingVideosInRecentlyArchived: (show: boolean) =>
         set({ showProcessingVideosInRecentlyArchived: show }),
+
+      setShowAbsoluteTime: (show: boolean) => set({ showAbsoluteTime: show }),
     }),
     {
       name: "settings-storage",
@@ -59,6 +64,7 @@ const useSettingsStore = create<SettingsState>()(
         showProcessingVideosInRecentlyArchived:
           state.showProcessingVideosInRecentlyArchived,
         hideChat: state.hideChat,
+        showAbsoluteTime: state.showAbsoluteTime,
       }),
     },
   ),

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -811,6 +811,7 @@
     "theaterModeIconTooltip": "Theater Mode",
     "hideChatIconTooltip": "Chat verbergen",
     "showChatIconTooltip": "Chat anzeigen",
+    "absoluteTimeIconTooltip": "Absolute Zeit umschalten",
     "sourceViewsTooltip": "Quell-views",
     "localViewsTooltip": "Lokale views",
     "streamedOnTooltip": "Gestreamt am",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -811,6 +811,7 @@
     "theaterModeIconTooltip": "Theater Mode",
     "hideChatIconTooltip": "Hide Chat",
     "showChatIconTooltip": "Show Chat",
+    "absoluteTimeIconTooltip": "Toggle Absolute Time",
     "sourceViewsTooltip": "source views",
     "localViewsTooltip": "local views",
     "streamedOnTooltip": "Streamed on",

--- a/frontend/messages/uk.json
+++ b/frontend/messages/uk.json
@@ -809,6 +809,7 @@
     "theaterModeIconTooltip": "Театральний режим",
     "hideChatIconTooltip": "Приховати чат",
     "showChatIconTooltip": "Показати чат",
+    "absoluteTimeIconTooltip": "Перемкнути абсолютний час",
     "sourceViewsTooltip": "перегляди джерела",
     "localViewsTooltip": "локальні перегляди",
     "streamedOnTooltip": "Трансляція від",


### PR DESCRIPTION
## Summary

- Adds an overlay to the video player that shows the real-world clock time at the current playback position (calculated from `streamed_at` + current playback time).
- Adds a toggle button (clock icon) to the player controls next to the existing theater-mode and hide-chat buttons. The preference is persisted per-user via the settings store.
- Adds translations for `en`, `de`, and `uk`.  

Closes #1002

## Screenshots

### overlay
<img width="506" height="338" alt="grafik" src="https://github.com/user-attachments/assets/4aef4ae0-c53d-4ef1-ad85-de29067416dd" />

### toggle button
<img width="386" height="244" alt="grafik" src="https://github.com/user-attachments/assets/a84df6aa-261d-47d1-8a42-ff8117d30d6c" />
