### PR TITLE
archive: keep slashes in folder template

### DIFF
--- a/internal/archive/utils.go
+++ b/internal/archive/utils.go
@@ -71,7 +71,11 @@ func GetFolderName(uuid uuid.UUID, input StorageTemplateInput) (string, error) {
 
 	}
 
-	folderTemplate = utils.SanitizeFileName(folderTemplate)
+	parts := strings.Split(folderTemplate, "/")
+	for i, p := range parts {
+		parts[i] = utils.SanitizeFileName(p)
+	}
+	folderTemplate = strings.Join(parts, "/")
 
 	return folderTemplate, nil
 }


### PR DESCRIPTION
Closes #1162.

`/` is sanitized to `_` so `{{YYYY}}/{{MM}}/...` collapses into one folder. Sanitize each path segment instead of the whole string.