### PR TITLE
fix(archive): preserve nested directory structure in folder template

### DIFF
--- a/internal/archive/utils.go
+++ b/internal/archive/utils.go
@@ -85,6 +85,9 @@ func GetFolderName(uuid uuid.UUID, input StorageTemplateInput) (string, error) {
 		}
 		renderedSegments = append(renderedSegments, utils.SanitizeFileName(rendered))
 	}
+	if len(renderedSegments) == 0 {
+		return "", fmt.Errorf("rendered folder template is empty after processing; check folder_template configuration")
+	}
 	folderTemplate = strings.Join(renderedSegments, "/")
 
 	return folderTemplate, nil

--- a/internal/archive/utils.go
+++ b/internal/archive/utils.go
@@ -53,25 +53,34 @@ func GetFolderName(uuid uuid.UUID, input StorageTemplateInput) (string, error) {
 		folderTemplate = "{{id}}-{{uuid}}"
 	}
 
-	res := storageTemplateVariableRegex.FindAllStringSubmatch(folderTemplate, -1)
-	for _, match := range res {
-		// Get variable name
-		variableName := match[1]
-		// Get variable value
-		variableValue, ok := variableMap[variableName]
-		if !ok {
-			return "", fmt.Errorf("variable %s not found in variable map", variableName)
+	// Split the template on '/' first, then render and sanitize each segment in
+	// isolation. This preserves '/' that the user wrote as directory separators
+	// in the template, while flattening any '/' that appears inside a substituted
+	// variable value (e.g. a video title) to '_' so it cannot create unintended
+	// directory levels. SanitizeFileName also maps a segment of "." or ".." to
+	// "unnamed_file", so path traversal from variable substitutions is neutralized.
+	templateSegments := strings.Split(folderTemplate, "/")
+	renderedSegments := make([]string, len(templateSegments))
+	for i, segment := range templateSegments {
+		rendered := segment
+		for _, match := range storageTemplateVariableRegex.FindAllStringSubmatch(segment, -1) {
+			// Get variable name
+			variableName := match[1]
+			// Get variable value
+			variableValue, ok := variableMap[variableName]
+			if !ok {
+				return "", fmt.Errorf("variable %s not found in variable map", variableName)
+			}
+			// Replace variable in segment
+			valueString := fmt.Sprintf("%v", variableValue)
+			if valueString == "" {
+				return "", fmt.Errorf("variable %s resolved to empty string; ensure the archive has this field populated", variableName)
+			}
+			rendered = strings.ReplaceAll(rendered, match[0], valueString)
 		}
-		// Replace variable in template
-		folderString := fmt.Sprintf("%v", variableValue)
-		if folderString == "" {
-			return "", fmt.Errorf("variable %s resolved to empty string; ensure the archive has this field populated", variableName)
-		}
-		folderTemplate = strings.ReplaceAll(folderTemplate, match[0], folderString)
-
+		renderedSegments[i] = utils.SanitizeFileName(rendered)
 	}
-
-	folderTemplate = utils.SanitizeFileName(folderTemplate)
+	folderTemplate = strings.Join(renderedSegments, "/")
 
 	return folderTemplate, nil
 }

--- a/internal/archive/utils.go
+++ b/internal/archive/utils.go
@@ -59,9 +59,14 @@ func GetFolderName(uuid uuid.UUID, input StorageTemplateInput) (string, error) {
 	// variable value (e.g. a video title) to '_' so it cannot create unintended
 	// directory levels. SanitizeFileName also maps a segment of "." or ".." to
 	// "unnamed_file", so path traversal from variable substitutions is neutralized.
+	// Empty segments produced by leading, trailing, or consecutive slashes are
+	// skipped so they do not become spurious "unnamed_file" directories.
 	templateSegments := strings.Split(folderTemplate, "/")
-	renderedSegments := make([]string, len(templateSegments))
-	for i, segment := range templateSegments {
+	renderedSegments := make([]string, 0, len(templateSegments))
+	for _, segment := range templateSegments {
+		if segment == "" {
+			continue
+		}
 		rendered := segment
 		for _, match := range storageTemplateVariableRegex.FindAllStringSubmatch(segment, -1) {
 			// Get variable name
@@ -78,7 +83,7 @@ func GetFolderName(uuid uuid.UUID, input StorageTemplateInput) (string, error) {
 			}
 			rendered = strings.ReplaceAll(rendered, match[0], valueString)
 		}
-		renderedSegments[i] = utils.SanitizeFileName(rendered)
+		renderedSegments = append(renderedSegments, utils.SanitizeFileName(rendered))
 	}
 	folderTemplate = strings.Join(renderedSegments, "/")
 

--- a/internal/archive/utils_test.go
+++ b/internal/archive/utils_test.go
@@ -102,6 +102,104 @@ func TestGetFolderName(t *testing.T) {
 	}
 }
 
+// TestGetFolderName_PathSafety verifies that '/' and '..' coming from
+// substituted variable values cannot escape their folder segment. Template
+// '/' is preserved as a directory separator (covered by TestGetFolderName);
+// these cases pin the dual property that variable-value '/' gets flattened
+// and that bare "." / ".." segments are neutralized by SanitizeFileName.
+func TestGetFolderName_PathSafety(t *testing.T) {
+	// Setup the application
+	_, err := tests.Setup(t)
+	assert.NoError(t, err)
+
+	testUUID := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+
+	tests := []struct {
+		name        string
+		template    string
+		input       archive.StorageTemplateInput
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "slash inside variable value is flattened, not treated as a separator",
+			template: "{{channel}}/{{title}}",
+			input: archive.StorageTemplateInput{
+				UUID:    testUUID,
+				ID:      "testid",
+				Channel: "testchannel",
+				Title:   "Series/Episode 1",
+				Type:    "video",
+				Date:    "2025-08-04",
+				YYYY:    "2025",
+				MM:      "08",
+				DD:      "04",
+				HH:      "12",
+			},
+			expected:    "testchannel/Series_Episode_1",
+			expectError: false,
+		},
+		{
+			name:     "double-dot variable value is neutralized to unnamed_file",
+			template: "{{channel}}/{{title}}",
+			input: archive.StorageTemplateInput{
+				UUID:    testUUID,
+				ID:      "testid",
+				Channel: "testchannel",
+				Title:   "..",
+				Type:    "video",
+				Date:    "2025-08-04",
+				YYYY:    "2025",
+				MM:      "08",
+				DD:      "04",
+				HH:      "12",
+			},
+			expected:    "testchannel/unnamed_file",
+			expectError: false,
+		},
+		{
+			name:     "single-dot variable value is neutralized to unnamed_file",
+			template: "{{channel}}/{{title}}",
+			input: archive.StorageTemplateInput{
+				UUID:    testUUID,
+				ID:      "testid",
+				Channel: "testchannel",
+				Title:   ".",
+				Type:    "video",
+				Date:    "2025-08-04",
+				YYYY:    "2025",
+				MM:      "08",
+				DD:      "04",
+				HH:      "12",
+			},
+			expected:    "testchannel/unnamed_file",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := config.Get()
+			c.StorageTemplates.FolderTemplate = tt.template
+			assert.NoError(t, config.UpdateConfig(c), "failed to update config with template")
+
+			result, err := archive.GetFolderName(testUUID, tt.input)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("GetFolderName() = %q, expected %q", result, tt.expected)
+				}
+			}
+		})
+	}
+}
+
 // TestGetFileName tests the GetFileName function with various templates and inputs.
 func TestGetFileName(t *testing.T) {
 	// Setup the application

--- a/internal/archive/utils_test.go
+++ b/internal/archive/utils_test.go
@@ -75,6 +75,24 @@ func TestGetFolderName(t *testing.T) {
 			expected:    "2025/08/2025-08-04-video-123e4567-e89b-12d3-a456-426614174000",
 			expectError: false,
 		},
+		{
+			name:        "template with trailing slash drops the empty segment",
+			template:    "{{YYYY}}/{{MM}}/",
+			expected:    "2025/08",
+			expectError: false,
+		},
+		{
+			name:        "template with leading slash drops the empty segment",
+			template:    "/{{YYYY}}/{{MM}}",
+			expected:    "2025/08",
+			expectError: false,
+		},
+		{
+			name:        "template with consecutive slashes drops the empty segment",
+			template:    "{{YYYY}}//{{MM}}",
+			expected:    "2025/08",
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/archive/utils_test.go
+++ b/internal/archive/utils_test.go
@@ -69,6 +69,12 @@ func TestGetFolderName(t *testing.T) {
 			expected:    "TestChannel-2025-08-04-testid",
 			expectError: false,
 		},
+		{
+			name:        "template with nested directory structure",
+			template:    "{{YYYY}}/{{MM}}/{{date}}-{{type}}-{{uuid}}",
+			expected:    "2025/08/2025-08-04-video-123e4567-e89b-12d3-a456-426614174000",
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/archive/utils_test.go
+++ b/internal/archive/utils_test.go
@@ -93,6 +93,12 @@ func TestGetFolderName(t *testing.T) {
 			expected:    "2025/08",
 			expectError: false,
 		},
+		{
+			name:        "template that resolves to no segments returns an error",
+			template:    "///",
+			expected:    "",
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Fixes #1162: forward slashes in `folder_template` (e.g. `{{YYYY}}/{{MM}}/...`) were flattened to `_` by `SanitizeFileName`, so users intending nested directories got a single flat folder.
- Splits the template on `/` first, then renders and sanitizes each segment in isolation. Template `/` survives as a directory separator; `/` from variable values stays flattened.
- No schema migration, no behavior change for users whose template doesn't contain `/`.

## Differences from #1163

#1163 split *after* substitution, which let a `/` inside a variable value (e.g. `{{title}} = "Series/Episode 1"`) inject unintended directory levels (which @coderabbitai correctly flagged) . This PR splits the **template** first, so:

- A literal `/` in the template → directory separator.
- A `/` inside a substituted variable value → flattened to `_` by `SanitizeFileName` within its segment.
- A `.` or `..` substituted into a segment → mapped to `unnamed_file` by `SanitizeFileName`'s existing guard, neutralizing path traversal.

`TestGetFolderName_PathSafety` pins all three invariants.