### PR TITLE
fix(frontend): refresh continue watching and card progress without reload

### DIFF
--- a/frontend/app/components/videos/Card.tsx
+++ b/frontend/app/components/videos/Card.tsx
@@ -1,7 +1,7 @@
 import { Video } from "@/app/hooks/useVideos";
 import { Badge, Card, Image, Progress, Tooltip, Text, Title, Group, Center, Avatar, Flex, ThemeIcon, LoadingOverlay, Loader, Box, Checkbox } from "@mantine/core";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import localizedFormat from "dayjs/plugin/localizedFormat";
@@ -45,9 +45,6 @@ const VideoCard = ({
   const { isLoggedIn, hasPermission } = useAuthStore()
   const [thumbnailError, setThumbnailError] = useState(false);
 
-  const [playbackProgress, setPlaybackProgress] = useState(0);
-  const [playbackIsWatched, setPlaybackIsWatched] = useState(false)
-
   // Handle thumbnail loading error
   const handleThumbnailError = () => {
     setThumbnailError(true);
@@ -62,12 +59,8 @@ const VideoCard = ({
     }
   );
 
-  // Set playback state
-  useEffect(() => {
-    if (!playbackData) return
-    setPlaybackProgress(((playbackData.time) / video.duration) * 100);
-    setPlaybackIsWatched(playbackData.status == PlaybackStatus.Finished)
-  }, [playbackData, video.duration])
+  const playbackProgress = playbackData ? (playbackData.time / video.duration) * 100 : 0;
+  const playbackIsWatched = playbackData?.status === PlaybackStatus.Finished;
 
   return (
     <Card radius="md" padding={5} className={classes.card}>

--- a/frontend/app/components/videos/Grid.tsx
+++ b/frontend/app/components/videos/Grid.tsx
@@ -242,7 +242,10 @@ const VideoGrid = <T extends Video>({
         }),
       t("markedVideosAsWatchedNotification"),
       async () => {
-        await queryClient.invalidateQueries({ queryKey: ["playback-data"] });
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["playback-data"] }),
+          queryClient.invalidateQueries({ queryKey: ["playback-videos"] }),
+        ]);
       }
     );
   };
@@ -259,7 +262,10 @@ const VideoGrid = <T extends Video>({
         }),
       t("markedVideosAsUnwatchedNotification"),
       async () => {
-        await queryClient.invalidateQueries({ queryKey: ["playback-data"] });
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["playback-data"] }),
+          queryClient.invalidateQueries({ queryKey: ["playback-videos"] }),
+        ]);
       }
     );
   };

--- a/frontend/app/components/videos/Player.tsx
+++ b/frontend/app/components/videos/Player.tsx
@@ -119,17 +119,17 @@ const VideoPlayer = ({ video, ref }: Params) => {
     });
 
     if (!hasInitializedPlaybackTime.current) {
-      // Resume from server-side playback progress.
-      if (playbackData && playbackData.time) {
+      if (playbackData && playbackData.time != null) {
+        // Resume from server-side playback progress.
         player.current!.currentTime = playbackData.time
         hasInitializedPlaybackTime.current = true
-      }
-
-      // Check if time is set in the url
-      const time = searchParams.get("t");
-      if (time) {
-        player.current!.currentTime = parseInt(time);
-        hasInitializedPlaybackTime.current = true
+      } else {
+        // Check if time is set in the url
+        const time = searchParams.get("t");
+        if (time !== null) {
+          player.current!.currentTime = parseInt(time);
+          hasInitializedPlaybackTime.current = true
+        }
       }
     }
 

--- a/frontend/app/components/videos/Player.tsx
+++ b/frontend/app/components/videos/Player.tsx
@@ -48,6 +48,7 @@ const VideoPlayer = ({ video, ref }: Params) => {
   const [videoPoster, setVideoPoster] = useState<string>("");
 
   const hasStartedPlayback = useRef(false);
+  const hasInitializedPlaybackTime = useRef(false);
 
   const [playerVolume, setPlayerVolume] = useState(1);
 
@@ -117,15 +118,19 @@ const VideoPlayer = ({ video, ref }: Params) => {
       }
     });
 
-    // Resume from server-side playback progress.
-    if (playbackData && playbackData.time) {
-      player.current!.currentTime = playbackData.time
-    }
+    if (!hasInitializedPlaybackTime.current) {
+      // Resume from server-side playback progress.
+      if (playbackData && playbackData.time) {
+        player.current!.currentTime = playbackData.time
+        hasInitializedPlaybackTime.current = true
+      }
 
-    // Check if time is set in the url
-    const time = searchParams.get("t");
-    if (time) {
-      player.current!.currentTime = parseInt(time);
+      // Check if time is set in the url
+      const time = searchParams.get("t");
+      if (time) {
+        player.current!.currentTime = parseInt(time);
+        hasInitializedPlaybackTime.current = true
+      }
     }
 
   }, [player, video, playbackData, searchParams])

--- a/frontend/app/hooks/usePlayback.ts
+++ b/frontend/app/hooks/usePlayback.ts
@@ -60,7 +60,6 @@ const useFetchPlaybackForVideo = (
     queryKey: ["playback-data", videoId],
     queryFn: () => fetchPlaybackForVideo(axiosPrivate, videoId),
     refetchInterval: false,
-    refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     refetchIntervalInBackground: false,
@@ -91,9 +90,14 @@ const useStartPlaybackForVideo = (
     "queryKey" | "queryFn"
   >
 ) => {
+  const queryClient = useQueryClient();
   return useMutation<ApiResponse<NullResponse>, Error, void, [string, string]>({
     mutationFn: () => startPlaybackForVideo(axiosPrivate, videoId),
     ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: ["playback-videos"] });
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
   });
 };
 
@@ -118,6 +122,7 @@ const updatePlaybackProgressForVideo = async (
 
 // Custom hook that uses the mutation with proper typing
 const useUpdatePlaybackProgressForVideo = () => {
+  const queryClient = useQueryClient();
   return useMutation<
     ApiResponse<NullResponse>,
     Error,
@@ -125,6 +130,10 @@ const useUpdatePlaybackProgressForVideo = () => {
   >({
     mutationFn: ({ axiosPrivate, videoId, time }) =>
       updatePlaybackProgressForVideo(axiosPrivate, videoId, time),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["playback-videos"] });
+      queryClient.invalidateQueries({ queryKey: ["playback-data", variables.videoId] });
+    },
   });
 };
 
@@ -149,6 +158,7 @@ const setPlaybackProgressForVideo = async (
 
 // Custom hook that uses the mutation with proper typing
 const useSetPlaybackProgressForVideo = () => {
+  const queryClient = useQueryClient();
   return useMutation<
     ApiResponse<NullResponse>,
     Error,
@@ -156,6 +166,10 @@ const useSetPlaybackProgressForVideo = () => {
   >({
     mutationFn: ({ axiosPrivate, videoId, status }) =>
       setPlaybackProgressForVideo(axiosPrivate, videoId, status),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["playback-videos"] });
+      queryClient.invalidateQueries({ queryKey: ["playback-data", variables.videoId] });
+    },
   });
 };
 
@@ -216,6 +230,7 @@ const useMarkVideoAsWatched = () => {
       onSuccess: (_, variables) => {
         if (variables.invalidatePlaybackQuery !== false) {
           queryClient.invalidateQueries({ queryKey: ["playback-data"] });
+          queryClient.invalidateQueries({ queryKey: ["playback-videos"] });
         }
       },
     }
@@ -235,6 +250,7 @@ const useDeletePlayback = () => {
     onSuccess: (_, variables) => {
       if (variables.invalidatePlaybackQuery !== false) {
         queryClient.invalidateQueries({ queryKey: ["playback-data"] });
+        queryClient.invalidateQueries({ queryKey: ["playback-videos"] });
       }
     },
   });


### PR DESCRIPTION
## Summary

- Continue Watching now drops a video immediately when marked unwatched, and adds a video after playback without needing a reload.
- Per-card progress bars / watched icons on Videos / channel / search pages update without a reload after playing or marking a video.

## Changes

- `usePlayback.ts`: invalidate `["playback-videos"]` (and `["playback-data", videoId]` where relevant) from `useStartPlaybackForVideo`, `useUpdatePlaybackProgressForVideo`, `useSetPlaybackProgressForVideo`, `useMarkVideoAsWatched`, `useDeletePlayback`. Drop `refetchOnMount: false` from `useFetchPlaybackForVideo`.
- `Card.tsx`: derive `playbackProgress` / `playbackIsWatched` from query data instead of mirroring into `useState` (so deletion correctly resets the UI).
- `Grid.tsx`: bulk mark-watched/unwatched also invalidates `["playback-videos"]`.
- `Player.tsx`: guard the resume-from-progress / URL-`t`-param blocks with a ref so they only run once — fixes the heartbeat-induced backward skip introduced by the per-video invalidation above.
