### PR TITLE
fix(video): keep player and chat mounted across mobile/desktop switch

### DIFF
--- a/frontend/app/videos/[id]/page.tsx
+++ b/frontend/app/videos/[id]/page.tsx
@@ -67,77 +67,50 @@ const VideoPage = ({ params }: { params: Promise<Params> }) => {
     return <VideoLoginRequired video={data} />
   }
 
-  if (isMobile) {
-    return (
-      <Box className={classes.containerMobile}>
-
-        {/* Video player */}
-        <div>
-          <VideoPlayer video={data} ref={player} />
-        </div>
-
-        {/* Chat player */}
-        {data.chat_path && !hideChat && !data.processing && (
-          <div className={classes.chatColumnMobile}>
-            <ChatPlayer video={data} playerRef={player} />
-          </div>
-        )}
-
-        {/* Title bar */}
-        {!videoTheaterMode && <VideoTitleBar video={data} />}
-
-        {/* Items below the player are not available in mobile */}
-
-      </Box>
-    )
-  }
-
   return (
     <div>
-      {/* Hide navbar. I don't like doing this but the navbar ruins the experience */}
-      <style jsx>{`
-        :global(html)::-webkit-scrollbar {
-          display: none;
-        }
-        :global(html) {
-          -ms-overflow-style: none; /* IE and Edge */
-          scrollbar-width: none; /* Firefox */
-        }
-      `}</style>
-
-      {/* Player and chat section */}
-      <Box className={classes.container}>
+      {/* Player and chat section — single tree on both layouts so VideoPlayer/ChatPlayer instances persist across the breakpoint flip */}
+      <Box className={isMobile ? classes.containerMobile : classes.container}>
         {/* Player */}
-        <div className={!data.chat_path ? classes.leftColumnNoChat : classes.leftColumn}>
+        <div className={
+          isMobile
+            ? undefined
+            : (!data.chat_path ? classes.leftColumnNoChat : classes.leftColumn)
+        }>
           <div className={
-            videoTheaterMode || fullscreen ? classes.videoPlayerTheaterMode : classes.videoPlayer
+            isMobile
+              ? undefined
+              : (videoTheaterMode || fullscreen ? classes.videoPlayerTheaterMode : classes.videoPlayer)
           }>
             <VideoPlayer video={data} ref={player} />
           </div>
         </div>
 
-
         {/* Chat */}
         {data.chat_path && !hideChat && !data.processing && (
-          <div className={classes.rightColumn} style={{ height: "auto", maxHeight: "auto" }}>
-            <div className={
-              videoTheaterMode || fullscreen
-                ? classes.chatColumnTheaterMode
-                : classes.chatColumn
-            }
+          <div
+            className={isMobile ? classes.chatColumnMobile : classes.rightColumn}
+            style={isMobile ? undefined : { height: "auto", maxHeight: "auto" }}
+          >
+            <div
+              className={
+                isMobile
+                  ? undefined
+                  : (videoTheaterMode || fullscreen ? classes.chatColumnTheaterMode : classes.chatColumn)
+              }
+              style={isMobile ? { height: "100%" } : undefined}
             >
               <ChatPlayer video={data} playerRef={player} />
             </div>
           </div>
         )}
-
       </Box>
 
       {/* Title bar */}
       {!videoTheaterMode && <VideoTitleBar video={data} />}
 
-      {/* Video clips */}
-      {!data.processing && (
+      {/* Desktop-only sections render after the player/chat block so toggling them doesn't shift player position */}
+      {!isMobile && !data.processing && (
         <Container size="7xl" fluid={true} >
           {videoClipsError && (
             <div>Error loading clips</div>
@@ -148,13 +121,23 @@ const VideoPage = ({ params }: { params: Promise<Params> }) => {
         </Container>
       )}
 
-      {/* Chat Histogram */}
-      {(data.chat_path && (data.type != VideoType.Clip) && !isMobile && showChatHistogram && !data.processing) && (
+      {(!isMobile && data.chat_path && (data.type != VideoType.Clip) && showChatHistogram && !data.processing) && (
         <Container size="7xl" fluid={true} >
           <VideoChatHistogram videoId={data.id} playerRef={player} />
         </Container>
       )}
 
+      {!isMobile && (
+        <style jsx>{`
+          :global(html)::-webkit-scrollbar {
+            display: none;
+          }
+          :global(html) {
+            -ms-overflow-style: none; /* IE and Edge */
+            scrollbar-width: none; /* Firefox */
+          }
+        `}</style>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Resizing the window across the `sm` (48em) breakpoint caused the video to seek back to the last server-saved time, and the chat to clear all messages.

The page at `frontend/app/videos/[id]/page.tsx` had two separate `return` statements, one for mobile and one for desktop. Flipping `isMobile` swapped the entire JSX tree, so React unmounted both `<VideoPlayer>` and `<ChatPlayer>` and mounted fresh ones. The new player then ran its mount-time playback-resume effect and reset `currentTime`, and the new chat player wiped its message buffer.

This PR merges the two trees into one, with `<VideoPlayer>` and `<ChatPlayer>` at stable positions on both layouts. Layout differences (flex direction, column widths, theater-mode wrappers, scrollbar-hide) are now driven by conditional `className` and trailing conditional siblings, so React preserves the component instances across the breakpoint flip.