### PR TITLE
feat(frontend): show skeleton placeholder while card images load

### DIFF
--- a/frontend/app/components/channel/Card.tsx
+++ b/frontend/app/components/channel/Card.tsx
@@ -1,6 +1,9 @@
+"use client"
+
 import { Channel } from "@/app/hooks/useChannels";
-import { AspectRatio, Card, Center, Title, Image } from "@mantine/core";
+import { AspectRatio, Card, Center, Title, Image, Skeleton } from "@mantine/core";
 import Link from "next/link";
+import { useState } from "react";
 import { env } from "next-runtime-env";
 import classes from "./Card.module.css"
 
@@ -9,12 +12,22 @@ type Props = {
 }
 
 const ChannelCard = ({ channel }: Props) => {
+  const [imageLoaded, setImageLoaded] = useState(false);
+
   return (
     <div>
       <Link href={"/channels/" + channel.name} className={classes.link}>
         <Card key={channel.id} p="md" radius="md" >
           <AspectRatio ratio={300 / 300}>
-            <Image src={`${(env('NEXT_PUBLIC_CDN_URL') ?? '')}${channel.image_path}`} alt={`${channel.name}`} fallbackSrc="/images/ganymede_default_channel_image.webp" />
+            <Skeleton visible={!imageLoaded} animate radius="md">
+              <Image
+                src={`${(env('NEXT_PUBLIC_CDN_URL') ?? '')}${channel.image_path}`}
+                alt={`${channel.name}`}
+                fallbackSrc="/images/ganymede_default_channel_image.webp"
+                onLoad={() => setImageLoaded(true)}
+                onError={() => setImageLoaded(true)}
+              />
+            </Skeleton>
           </AspectRatio>
           <Center mt={5}>
             <Title order={3} mt={5}>

--- a/frontend/app/components/channel/Card.tsx
+++ b/frontend/app/components/channel/Card.tsx
@@ -3,7 +3,7 @@
 import { Channel } from "@/app/hooks/useChannels";
 import { AspectRatio, Card, Center, Title, Image, Skeleton } from "@mantine/core";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { env } from "next-runtime-env";
 import classes from "./Card.module.css"
 
@@ -13,6 +13,10 @@ type Props = {
 
 const ChannelCard = ({ channel }: Props) => {
   const [imageLoaded, setImageLoaded] = useState(false);
+
+  useEffect(() => {
+    setImageLoaded(false);
+  }, [channel.image_path]);
 
   return (
     <div>

--- a/frontend/app/components/videos/Card.module.css
+++ b/frontend/app/components/videos/Card.module.css
@@ -19,6 +19,8 @@
 
 .videoImageWrapper {
   position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
 }
 
 .selectionCheckboxInline {

--- a/frontend/app/components/videos/Card.tsx
+++ b/frontend/app/components/videos/Card.tsx
@@ -1,5 +1,5 @@
 import { Video } from "@/app/hooks/useVideos";
-import { Badge, Card, Image, Progress, Tooltip, Text, Title, Group, Center, Avatar, Flex, ThemeIcon, LoadingOverlay, Loader, Box, Checkbox } from "@mantine/core";
+import { Badge, Card, Image, Progress, Tooltip, Text, Title, Group, Center, Avatar, Flex, ThemeIcon, LoadingOverlay, Loader, Box, Checkbox, Skeleton } from "@mantine/core";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import dayjs from "dayjs";
@@ -44,6 +44,7 @@ const VideoCard = ({
   const t = useTranslations('VideoComponents')
   const { isLoggedIn, hasPermission } = useAuthStore()
   const [thumbnailError, setThumbnailError] = useState(false);
+  const [thumbnailLoaded, setThumbnailLoaded] = useState(false);
 
   const [playbackProgress, setPlaybackProgress] = useState(0);
   const [playbackIsWatched, setPlaybackIsWatched] = useState(false)
@@ -51,6 +52,7 @@ const VideoCard = ({
   // Handle thumbnail loading error
   const handleThumbnailError = () => {
     setThumbnailError(true);
+    setThumbnailLoaded(true);
   };
 
   const axiosPrivate = useAxiosPrivate();
@@ -84,17 +86,20 @@ const VideoCard = ({
                   </Center></div>
               }} />
             )}
-            <Image
-              className={classes.videoImage}
-              src={`${(env('NEXT_PUBLIC_CDN_URL') ?? '')}${escapeURL(
-                video.web_thumbnail_path
-              )}`}
-              onError={handleThumbnailError}
-              width={thumbnailError ? "100%" : "100%"}
-              height={thumbnailError ? "100%" : "100%"}
-              fallbackSrc="/images/ganymede-thumbnail.webp"
-              alt={video.title}
-            />
+            <Skeleton visible={!thumbnailLoaded} animate radius={0} height="100%">
+              <Image
+                className={classes.videoImage}
+                src={`${(env('NEXT_PUBLIC_CDN_URL') ?? '')}${escapeURL(
+                  video.web_thumbnail_path
+                )}`}
+                onLoad={() => setThumbnailLoaded(true)}
+                onError={handleThumbnailError}
+                width={thumbnailError ? "100%" : "100%"}
+                height={thumbnailError ? "100%" : "100%"}
+                fallbackSrc="/images/ganymede-thumbnail.webp"
+                alt={video.title}
+              />
+            </Skeleton>
 
             {video.sprite_thumbnails_enabled && (
               <VideoSpritePeek

--- a/frontend/app/components/videos/Card.tsx
+++ b/frontend/app/components/videos/Card.tsx
@@ -71,6 +71,10 @@ const VideoCard = ({
     setPlaybackIsWatched(playbackData.status == PlaybackStatus.Finished)
   }, [playbackData, video.duration])
 
+  useEffect(() => {
+    setThumbnailLoaded(false);
+  }, [video.web_thumbnail_path])
+
   return (
     <Card radius="md" padding={5} className={classes.card}>
       <Link href={`/videos/${video.id}`}>


### PR DESCRIPTION
## Summary
Currently when you open a page that lists videos or channels, the thumbnails pop in once the browser finishes fetching them. On video cards the layout also shifts, since the image wrapper has no aspect ratio set, so the slot is 0px tall until the image arrives.

This PR wraps each image in a Mantine Skeleton that shimmers until onLoad fires, and adds `aspect-ratio: 16 / 9` plus `overflow: hidden` to the video card wrapper so the space is reserved up front.

## Changes
- `videos/Card.tsx`: wrap Image in Skeleton, track `thumbnailLoaded`, also flip it on error so the fallback image shows instead of staying shimmery.
- `videos/Card.module.css`: aspect ratio and overflow on `.videoImageWrapper`.
- `channel/Card.tsx`: same skeleton pattern. Marked `"use client"` since it now uses `useState`. AspectRatio already handles the slot here.

The 24px channel Avatar inside the video card and the one in TitleBar are left alone, since Mantine Avatar already falls back to initials.
