### PR TITLE
fix(chat): forward shared user args to chatupdate and chatdownload

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -635,7 +635,9 @@ func extractSharedChatArgs(args []string) []string {
 		for _, flag := range sharedFlagNames {
 			if arg == flag {
 				result = append(result, arg)
-				if i+1 < len(args) {
+				// Only consume the next token as a value if it isn't itself a flag,
+				// otherwise `--stv --temp-path /p` would swallow `--temp-path`.
+				if i+1 < len(args) && !strings.HasPrefix(args[i+1], "--") {
 					result = append(result, args[i+1])
 					i++
 				}

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -502,7 +502,15 @@ func DownloadTwitchChat(ctx context.Context, video ent.Vod) error {
 	log.Debug().Str("video_id", video.ID.String()).Msgf("logging chatdownload output to %s", logFilePath)
 
 	var cmdArgs []string
-	cmdArgs = append(cmdArgs, "chatdownload", "--id", video.ExtID, "--embed-images", "--collision", "overwrite", "-o", video.TmpChatDownloadPath)
+	cmdArgs = append(cmdArgs, "chatdownload", "--id", video.ExtID, "--embed-images", "--collision", "overwrite")
+
+	// Forward shared chat flags from the chat render config so the user's
+	// --bttv/--ffz/--stv/--temp-path preferences also apply to chatdownload,
+	// which fetches emotes for embedding when --embed-images is set.
+	configRenderArgs := config.Get().Parameters.ChatRender
+	cmdArgs = append(cmdArgs, extractSharedChatArgs(strings.Fields(configRenderArgs))...)
+
+	cmdArgs = append(cmdArgs, "-o", video.TmpChatDownloadPath)
 
 	log.Debug().Str("video_id", video.ID.String()).Str("cmd", strings.Join(cmdArgs, " ")).Msgf("running TwitchDownloaderCLI")
 
@@ -616,6 +624,32 @@ func RenderTwitchChat(ctx context.Context, video ent.Vod) error {
 	return nil
 }
 
+// extractSharedChatArgs returns the subset of args from a chatrender arg list
+// that are also valid for chatupdate and chatdownload.
+func extractSharedChatArgs(args []string) []string {
+	// --collision is omitted: every caller hardcodes it.
+	sharedFlagNames := []string{"--bttv", "--ffz", "--stv", "--temp-path"}
+	var result []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		for _, flag := range sharedFlagNames {
+			if arg == flag {
+				result = append(result, arg)
+				if i+1 < len(args) {
+					result = append(result, args[i+1])
+					i++
+				}
+				break
+			}
+			if strings.HasPrefix(arg, flag+"=") {
+				result = append(result, arg)
+				break
+			}
+		}
+	}
+	return result
+}
+
 // checkLogForNoElements returns true if the log file contains the expected message.
 //
 // Used to check if the chat render failure was caused by no messages in the chat.
@@ -660,7 +694,16 @@ func UpdateTwitchChat(ctx context.Context, video ent.Vod) error {
 	log.Debug().Str("video_id", video.ID.String()).Msgf("logging TwitchDownloader output to %s", logFilePath)
 
 	var cmdArgs []string
-	cmdArgs = append(cmdArgs, "chatupdate", "-i", video.TmpLiveChatConvertPath, "--embed-missing", "--collision", "overwrite", "-o", video.TmpChatDownloadPath)
+	cmdArgs = append(cmdArgs, "chatupdate", "-i", video.TmpLiveChatConvertPath, "--embed-missing", "--collision", "overwrite")
+
+	// Forward shared chat flags from the chat render config so the user's
+	// --bttv/--ffz/--stv/--temp-path preferences also apply to chatupdate,
+	// which fetches emotes for embedding and can otherwise hang on a
+	// third-party timeout.
+	configRenderArgs := config.Get().Parameters.ChatRender
+	cmdArgs = append(cmdArgs, extractSharedChatArgs(strings.Fields(configRenderArgs))...)
+
+	cmdArgs = append(cmdArgs, "-o", video.TmpChatDownloadPath)
 
 	log.Debug().Str("video_id", video.ID.String()).Str("cmd", strings.Join(cmdArgs, " ")).Msgf("running TwitchDownloaderCLI")
 

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -1,1 +1,74 @@
 package exec
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_extractSharedChatArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "empty",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "no shared flags",
+			in:   []string{"-h", "1440", "-w", "340", "--font", "Inter"},
+			want: nil,
+		},
+		{
+			name: "equals form",
+			in:   []string{"-h", "1440", "--stv=false", "--font", "Inter"},
+			want: []string{"--stv=false"},
+		},
+		{
+			name: "space form",
+			in:   []string{"--bttv", "false", "-h", "1440"},
+			want: []string{"--bttv", "false"},
+		},
+		{
+			name: "all three providers mixed forms",
+			in:   []string{"--framerate", "30", "--bttv=true", "--ffz", "false", "--stv=false"},
+			want: []string{"--bttv=true", "--ffz", "false", "--stv=false"},
+		},
+		{
+			name: "temp-path space form",
+			in:   []string{"-h", "1440", "--temp-path", "/var/cache/td"},
+			want: []string{"--temp-path", "/var/cache/td"},
+		},
+		{
+			name: "temp-path equals form",
+			in:   []string{"--temp-path=/var/cache/td", "--font", "Inter"},
+			want: []string{"--temp-path=/var/cache/td"},
+		},
+		{
+			name: "trailing flag without value",
+			in:   []string{"--stv"},
+			want: []string{"--stv"},
+		},
+		{
+			name: "does not match prefix-only flags",
+			in:   []string{"--stvthing", "--bttvfoo=1", "--temp-pathish"},
+			want: nil,
+		},
+		{
+			name: "collision is intentionally not forwarded",
+			in:   []string{"--collision", "rename", "--stv=false"},
+			want: []string{"--stv=false"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractSharedChatArgs(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractSharedChatArgs(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -52,6 +52,11 @@ func Test_extractSharedChatArgs(t *testing.T) {
 			want: []string{"--stv"},
 		},
 		{
+			name: "bare boolean does not swallow following flag",
+			in:   []string{"--stv", "--temp-path", "/var/cache/td"},
+			want: []string{"--stv", "--temp-path", "/var/cache/td"},
+		},
+		{
 			name: "does not match prefix-only flags",
 			in:   []string{"--stvthing", "--bttvfoo=1", "--temp-pathish"},
 			want: nil,


### PR DESCRIPTION
## Summary
- Fixes #1172. `chatupdate` (live chat convert) and `chatdownload` (VOD chat) ignored `Parameters.ChatRender`, so flags like `--stv=false` only reached `chatrender`. With `--embed-missing`/`--embed-images` always set by Ganymede and the upstream `--stv` defaulting to `true`, a 7TV outage hung chat convert with an unhandled `TaskCanceledException`.
- Added `extractSharedChatArgs` to pull flags valid across all three TwitchDownloaderCLI chat subcommands (`--bttv`, `--ffz`, `--stv`, `--temp-path`) from the existing `ChatRender` config and forward them to `UpdateTwitchChat` and `DownloadTwitchChat`. `--collision` stays hardcoded.
- Default config extracts nothing, so existing installs are unchanged.
