### PR TITLE
fix: proxy playlist parsing logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	entgo.io/ent v0.14.6
 	github.com/alexedwards/scs/pgxstore v0.0.0-20240316134038-7e11d57e8885
 	github.com/alexedwards/scs/v2 v2.9.0
+	github.com/bluenviron/gohlslib/v2 v2.4.0
 	github.com/canidam/echo-scs-session v1.0.0
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/gavv/httpexpect/v2 v2.17.0
@@ -13,7 +14,6 @@ require (
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/uuid v1.6.0
-	github.com/grafov/m3u8 v0.12.1
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.15.2
 	github.com/lib/pq v1.12.3

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bluenviron/gohlslib/v2 v2.4.0 h1:O0bmUvyOMVPuRx3givLqfGWUzOKicKwkSCInpGxsXQA=
+github.com/bluenviron/gohlslib/v2 v2.4.0/go.mod h1:iqU6QJ5geVuCDpUeAbK/Si2RtDC3ocBTp8LnPHBkN6U=
 github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/canidam/echo-scs-session v1.0.0 h1:ubWTgxTQJwJjxNcvVzVlHk0x5Wd7+AeoGyT2+iYXiZE=
@@ -122,8 +124,6 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafov/m3u8 v0.12.1 h1:DuP1uA1kvRRmGNAZ0m+ObLv1dvrfNO0TPx0c/enNk0s=
-github.com/grafov/m3u8 v0.12.1/go.mod h1:nqzOkfBiZJENr52zTVd/Dcl03yzphIMbJqkXGu+u080=
 github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3qos=
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zibbp/ganymede/ent/vod"
 	"github.com/zibbp/ganymede/internal/archive"
 	"github.com/zibbp/ganymede/internal/config"
+	internalExec "github.com/zibbp/ganymede/internal/exec"
 	"github.com/zibbp/ganymede/internal/server"
 	"github.com/zibbp/ganymede/internal/utils"
 	"github.com/zibbp/ganymede/tests"
@@ -60,6 +61,28 @@ func (s *ArchiveTest) ArchiveChannelTest(t *testing.T) {
 	fileInfo, err := os.Stat(archivedPlatformChannel.ImagePath)
 	assert.NoError(t, err)
 	assert.NotEqual(t, 0, fileInfo.Size())
+}
+
+func assertAudioOnlyFile(t *testing.T, path string) {
+	t.Helper()
+
+	probeData, err := internalExec.GetFfprobeVideoData(t.Context(), path)
+	assert.NoError(t, err, "Failed to probe archived media")
+	assert.NotNil(t, probeData, "Expected ffprobe data for archived media")
+
+	audioStreams := 0
+	videoStreams := 0
+	for _, stream := range probeData.Streams {
+		switch stream.CodecType {
+		case "audio":
+			audioStreams++
+		case "video":
+			videoStreams++
+		}
+	}
+
+	assert.Greater(t, audioStreams, 0, "Archived media should contain at least one audio stream")
+	assert.Zero(t, videoStreams, "Archived media should not contain video streams")
 }
 
 // ArchiveVideo tests the full archive process for a video with chat downloading, processing, and rendering
@@ -267,6 +290,81 @@ func TestArchiveVideoNoChat(t *testing.T) {
 
 	// Assert video is playable
 	assert.True(t, tests_shared.IsPlayableVideo(v.VideoPath), "Video file is not playable")
+}
+
+// ArchiveVideo tests the full archive process for an audio-only video without chat downloading, processing, and rendering.
+func TestArchiveVideoAudioOnlyNoChat(t *testing.T) {
+	// Setup the application
+	app, err := tests.Setup(t)
+	assert.NoError(t, err)
+
+	// Archive the video
+	_, err = app.ArchiveService.ArchiveVideo(context.Background(), archive.ArchiveVideoInput{
+		VideoId:     TestTwitchVideoId,
+		Quality:     utils.Audio,
+		ArchiveChat: false,
+		RenderChat:  false,
+	})
+	assert.NoError(t, err)
+
+	// Assert video was created
+	v, err := app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
+
+	// Assert queue item was created
+	q, err := app.Database.Client.Queue.Query().Where(queue.HasVodWith(vod.ID(v.ID))).Only(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
+
+	assert.Equal(t, false, q.ChatProcessing)
+	assert.Equal(t, true, q.VideoProcessing)
+	assert.Equal(t, false, q.RenderChat)
+	assert.Equal(t, false, q.ArchiveChat)
+	assert.NotNil(t, q.WorkflowID)
+	assert.NotNil(t, q.WorkflowRunID)
+	assert.Equal(t, utils.Success, q.TaskChatDownload)
+	assert.Equal(t, utils.Success, q.TaskChatRender)
+	assert.Equal(t, utils.Success, q.TaskChatMove)
+	assert.Equal(t, utils.Pending, q.TaskVideoDownload)
+	assert.Equal(t, utils.Pending, q.TaskVideoConvert)
+	assert.Equal(t, utils.Pending, q.TaskVideoMove)
+
+	// Wait for the video to be archived
+	tests_shared.WaitForArchiveCompletion(t, app, v.ID, TestArchiveTimeout)
+
+	// Requery video
+	v, err = app.Database.Client.Vod.Query().Where(vod.ExtID(TestTwitchVideoId)).WithChapters().Only(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
+
+	// Assert queue item was updated
+	q, err = app.Database.Client.Queue.Query().Where(queue.HasVodWith(vod.ID(v.ID))).Only(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
+	assert.Equal(t, false, q.ChatProcessing)
+	assert.Equal(t, false, q.VideoProcessing)
+	assert.Equal(t, utils.Success, q.TaskChatDownload)
+	assert.Equal(t, utils.Success, q.TaskChatRender)
+	assert.Equal(t, utils.Success, q.TaskChatMove)
+	assert.Equal(t, utils.Success, q.TaskVideoDownload)
+	assert.Equal(t, utils.Success, q.TaskVideoConvert)
+	assert.Equal(t, utils.Success, q.TaskVideoMove)
+
+	// Assert files exist
+	assert.FileExists(t, v.ThumbnailPath)
+	assert.FileExists(t, v.WebThumbnailPath)
+	assert.FileExists(t, v.VideoPath)
+	assert.NoFileExists(t, v.ChatPath)
+	assert.NoFileExists(t, v.ChatVideoPath)
+
+	// Assert at least one chapter exists
+	assert.NotEmpty(t, v.Edges.Chapters, "Expected at least one chapter to be present")
+
+	assert.NotEqual(t, 0, v.StorageSizeBytes)
+
+	// Assert archived media is audio-only
+	assertAudioOnlyFile(t, v.VideoPath)
 }
 
 // ArchiveVideo tests the full archive process for a video without chat rendering

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -13,12 +13,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/grafov/m3u8"
 	"github.com/rs/zerolog/log"
 	"github.com/zibbp/ganymede/ent"
 	"github.com/zibbp/ganymede/internal/config"
 	"github.com/zibbp/ganymede/internal/errors"
 	"github.com/zibbp/ganymede/internal/exec/ytdlp"
+	"github.com/zibbp/ganymede/internal/hls"
 	"github.com/zibbp/ganymede/internal/platform"
 	"github.com/zibbp/ganymede/internal/utils"
 )
@@ -179,7 +179,7 @@ func DownloadTwitchLiveVideo(ctx context.Context, video ent.Vod, channel ent.Cha
 	log.Debug().Str("video_id", video.ID.String()).Msgf("logging ffmpeg output to %s", logFilePath)
 
 	proxyFound := false // Whether a proxy was found
-	var masterPlaylist *m3u8.MasterPlaylist
+	var masterPlaylist *hls.Multivariant
 
 	twitchURL := utils.CreateTwitchURL(video.ExtID, video.Type, channel.Name)
 

--- a/internal/exec/util.go
+++ b/internal/exec/util.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -58,15 +57,11 @@ func tryTwitchHLSProxy(proxyURL string, testURL string, header string) (*hls.Mul
 		return nil, false
 	}
 
-	fmt.Println("===")
-	// print body
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, hls.MaxPlaylistSize+1))
 	if err != nil {
 		log.Error().Err(err).Msg("error reading response body for Twitch HLS proxy server test")
 		return nil, false
 	}
-	fmt.Println(string(bodyBytes))
-	fmt.Println("===")
 
 	masterPlaylist, err := hls.DecodeMultivariant(bytes.NewReader(bodyBytes))
 	if err != nil {

--- a/internal/exec/util.go
+++ b/internal/exec/util.go
@@ -1,19 +1,22 @@
 package exec
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
-	"github.com/grafov/m3u8"
 	"github.com/rs/zerolog/log"
+	"github.com/zibbp/ganymede/internal/hls"
 	"github.com/zibbp/ganymede/internal/utils"
 )
 
-func tryProxyServer(proxyURL string, testURL string, header string, proxyType utils.ProxyType) (*m3u8.MasterPlaylist, bool) {
+func tryProxyServer(proxyURL string, testURL string, header string, proxyType utils.ProxyType) (*hls.Multivariant, bool) {
 	switch proxyType {
 	case utils.ProxyTypeTwitchHLS:
 		return tryTwitchHLSProxy(proxyURL, testURL, header)
@@ -25,7 +28,7 @@ func tryProxyServer(proxyURL string, testURL string, header string, proxyType ut
 	}
 }
 
-func tryTwitchHLSProxy(proxyURL string, testURL string, header string) (*m3u8.MasterPlaylist, bool) {
+func tryTwitchHLSProxy(proxyURL string, testURL string, header string) (*hls.Multivariant, bool) {
 	log.Debug().Msgf("testing Twitch HLS proxy server: %s", proxyURL)
 	client := &http.Client{
 		Timeout: 5 * time.Second,
@@ -55,15 +58,19 @@ func tryTwitchHLSProxy(proxyURL string, testURL string, header string) (*m3u8.Ma
 		return nil, false
 	}
 
-	playlist, _, err := m3u8.DecodeFrom(resp.Body, false)
+	fmt.Println("===")
+	// print body
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Error().Err(err).Msg("error decoding m3u8 response body for Twitch HLS proxy server test")
+		log.Error().Err(err).Msg("error reading response body for Twitch HLS proxy server test")
 		return nil, false
 	}
+	fmt.Println(string(bodyBytes))
+	fmt.Println("===")
 
-	masterPlaylist, ok := playlist.(*m3u8.MasterPlaylist)
-	if !ok {
-		log.Error().Msg("error casting playlist to a master playlist for Twitch HLS proxy server test")
+	masterPlaylist, err := hls.DecodeMultivariant(bytes.NewReader(bodyBytes))
+	if err != nil {
+		log.Error().Err(err).Msg("error decoding m3u8 response body for Twitch HLS proxy server test")
 		return nil, false
 	}
 
@@ -71,7 +78,7 @@ func tryTwitchHLSProxy(proxyURL string, testURL string, header string) (*m3u8.Ma
 	return masterPlaylist, true
 }
 
-func tryHTTPProxy(proxyURL string, testURL string, header string) (*m3u8.MasterPlaylist, bool) {
+func tryHTTPProxy(proxyURL string, testURL string, header string) (*hls.Multivariant, bool) {
 	log.Debug().Msgf("testing HTTP proxy server: %s", proxyURL)
 	parsedURL, err := url.Parse(proxyURL)
 	if err != nil {
@@ -123,15 +130,9 @@ func tryHTTPProxy(proxyURL string, testURL string, header string) (*m3u8.MasterP
 		return nil, false
 	}
 
-	playlist, _, err := m3u8.DecodeFrom(resp.Body, false)
+	masterPlaylist, err := hls.DecodeMultivariant(resp.Body)
 	if err != nil {
 		log.Error().Err(err).Msg("error decoding m3u8 response body for HTTP proxy server test")
-		return nil, false
-	}
-
-	masterPlaylist, ok := playlist.(*m3u8.MasterPlaylist)
-	if !ok {
-		log.Error().Msg("error casting playlist to a master playlist for HTTP proxy server test")
 		return nil, false
 	}
 

--- a/internal/hls/playlist.go
+++ b/internal/hls/playlist.go
@@ -1,0 +1,181 @@
+package hls
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/bluenviron/gohlslib/v2/pkg/playlist"
+	"github.com/bluenviron/gohlslib/v2/pkg/playlist/primitives"
+)
+
+const maxPlaylistSize = 1 * 1024 * 1024
+
+// Multivariant is a parsed HLS multivariant playlist.
+type Multivariant = playlist.Multivariant
+
+// DecodeMultivariant reads and parses an HLS multivariant playlist.
+func DecodeMultivariant(r io.Reader) (*Multivariant, error) {
+	byts, err := io.ReadAll(io.LimitReader(r, maxPlaylistSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(byts) > maxPlaylistSize {
+		return nil, fmt.Errorf("playlist exceeds maximum size of %d bytes", maxPlaylistSize)
+	}
+
+	byts, err = normalizeTwitchMultivariant(byts)
+	if err != nil {
+		return nil, err
+	}
+
+	pl, err := playlist.Unmarshal(byts)
+	if err != nil {
+		return nil, err
+	}
+
+	multivariant, ok := pl.(*playlist.Multivariant)
+	if !ok {
+		return nil, fmt.Errorf("playlist is %T, not *playlist.Multivariant", pl)
+	}
+
+	return multivariant, nil
+}
+
+func normalizeTwitchMultivariant(byts []byte) ([]byte, error) {
+	const prefix = "#EXT-X-STREAM-INF:"
+
+	if !strings.Contains(string(byts), prefix) {
+		return byts, nil
+	}
+
+	var b strings.Builder
+	lines := strings.SplitAfter(string(byts), "\n")
+	for _, line := range lines {
+		lineWithoutNewline := strings.TrimSuffix(line, "\n")
+		newline := line[len(lineWithoutNewline):]
+		lineWithoutCR := strings.TrimSuffix(lineWithoutNewline, "\r")
+		cr := lineWithoutNewline[len(lineWithoutCR):]
+
+		if strings.HasPrefix(lineWithoutCR, prefix) {
+			attrs := lineWithoutCR[len(prefix):]
+			normalizedAttrs, err := normalizeStreamInfAttributes(attrs)
+			if err != nil {
+				return nil, err
+			}
+			line = prefix + normalizedAttrs + cr + newline
+		}
+
+		b.WriteString(line)
+	}
+
+	return []byte(b.String()), nil
+}
+
+func normalizeStreamInfAttributes(attrsText string) (string, error) {
+	var attrs primitives.Attributes
+	if err := attrs.Unmarshal(attrsText); err != nil {
+		return "", fmt.Errorf("invalid #EXT-X-STREAM-INF attributes: %w", err)
+	}
+
+	if _, ok := attrs["VIDEO"]; ok {
+		return attrsText, nil
+	}
+
+	// https://eu.luminous.dev doesn't return a VIDEO attribute, but it can be derived from other attributes, so we add it if missing
+	label := twitchVariantVideoLabel(attrs)
+	if label == "" {
+		return attrsText, nil
+	}
+
+	separator := ","
+	if strings.TrimSpace(attrsText) == "" {
+		separator = ""
+	}
+
+	return attrsText + separator + `VIDEO="` + sanitizeHLSQuotedString(label) + `"`, nil
+}
+
+// twitchVariantVideoLabel generates a video label for a Twitch HLS variant based on its attributes
+// https://eu.luminous.dev doesn't return a VIDEO attribute, but it can be derived from other attributes, so we add it if missing
+func twitchVariantVideoLabel(attrs primitives.Attributes) string {
+	if label := attrs["STABLE-VARIANT-ID"]; label != "" {
+		return label
+	}
+	if label := attrs["IVS-NAME"]; label != "" {
+		return label
+	}
+
+	resolution := strings.TrimSpace(attrs["RESOLUTION"])
+	if resolution == "" {
+		if isAudioOnlyVariant(attrs) {
+			return "audio_only"
+		}
+		return ""
+	}
+
+	height := resolution
+	if parts := strings.SplitN(resolution, "x", 2); len(parts) == 2 {
+		height = parts[1]
+	}
+	height = strings.TrimSpace(height)
+	if height == "" {
+		return ""
+	}
+
+	label := height + "p"
+	if fps := roundedFrameRate(attrs["FRAME-RATE"]); fps != "" {
+		label += fps
+	}
+
+	return label
+}
+
+func isAudioOnlyVariant(attrs primitives.Attributes) bool {
+	codecs := attrs["CODECS"]
+	if codecs == "" {
+		return false
+	}
+
+	for _, codec := range strings.Split(codecs, ",") {
+		if isVideoCodec(strings.ToLower(strings.TrimSpace(codec))) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isVideoCodec(codec string) bool {
+	return strings.HasPrefix(codec, "avc") ||
+		strings.HasPrefix(codec, "hvc") ||
+		strings.HasPrefix(codec, "hev") ||
+		strings.HasPrefix(codec, "av01") ||
+		strings.HasPrefix(codec, "vp09") ||
+		strings.HasPrefix(codec, "vp8")
+}
+
+func roundedFrameRate(frameRate string) string {
+	if frameRate == "" {
+		return ""
+	}
+
+	fps, err := strconv.ParseFloat(frameRate, 64)
+	if err != nil {
+		return ""
+	}
+
+	rounded := int(math.Round(fps))
+	if rounded <= 0 {
+		return ""
+	}
+
+	return strconv.Itoa(rounded)
+}
+
+func sanitizeHLSQuotedString(s string) string {
+	replacer := strings.NewReplacer(`"`, "", "\r", "", "\n", "")
+	return replacer.Replace(s)
+}

--- a/internal/hls/playlist.go
+++ b/internal/hls/playlist.go
@@ -13,6 +13,9 @@ import (
 
 const maxPlaylistSize = 1 * 1024 * 1024
 
+// MaxPlaylistSize is the maximum allowed size for an HLS playlist.
+const MaxPlaylistSize = maxPlaylistSize
+
 // Multivariant is a parsed HLS multivariant playlist.
 type Multivariant = playlist.Multivariant
 

--- a/internal/hls/playlist_test.go
+++ b/internal/hls/playlist_test.go
@@ -1,0 +1,96 @@
+package hls
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeMultivariantTwitchStandardVideoAttributes(t *testing.T) {
+	input := `#EXTM3U
+#EXT-X-TWITCH-INFO:ORIGIN="sfo01",B="false"
+#EXT-X-STREAM-INF:BANDWIDTH=6000000,CODECS="avc1.64002a,mp4a.40.2",RESOLUTION=1920x1080,FRAME-RATE=60.000,VIDEO="chunked",AUDIO="audio"
+https://example.com/source/index-dvr.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=3000000,CODECS="avc1.640020,mp4a.40.2",RESOLUTION=1280x720,FRAME-RATE=60.000,VIDEO="720p60",AUDIO="audio"
+https://example.com/720p60/index-dvr.m3u8
+`
+
+	pl, err := DecodeMultivariant(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("DecodeMultivariant returned error: %v", err)
+	}
+
+	if len(pl.Variants) != 2 {
+		t.Fatalf("expected 2 variants, got %d", len(pl.Variants))
+	}
+
+	if pl.Variants[0].Video != "chunked" {
+		t.Fatalf("expected first variant video chunked, got %q", pl.Variants[0].Video)
+	}
+	if pl.Variants[1].Video != "720p60" {
+		t.Fatalf("expected second variant video 720p60, got %q", pl.Variants[1].Video)
+	}
+}
+
+func TestDecodeMultivariantTwitchSessionDataWithoutVideoAttributes(t *testing.T) {
+	input := `#EXTM3U
+#EXT-X-SESSION-DATA:DATA-ID="com.amazon.ivs.unavailable-video-reason",VALUE=""
+#EXT-X-SESSION-DATA:DATA-ID="com.amazon.ivs.broadcast-id",VALUE="example-broadcast"
+#EXT-X-SESSION-DATA:DATA-ID="com.amazon.ivs.stream-id",VALUE="example-stream"
+#EXT-X-SESSION-DATA:DATA-ID="com.amazon.ivs.live-low-latency",VALUE="true"
+#EXT-X-STREAM-INF:BANDWIDTH=900000,CODECS="avc1.64001e,mp4a.40.2",RESOLUTION=640x360,FRAME-RATE=30.000,STABLE-VARIANT-ID="360p30",IVS-NAME="360p30",AUDIO="audio"
+https://example.com/360p30/index-dvr.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=160000,CODECS="mp4a.40.2",AUDIO="audio"
+https://example.com/audio_only/index-dvr.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=6000000,CODECS="avc1.64002a,mp4a.40.2",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID="1080p60",IVS-NAME="source",AUDIO="audio"
+https://example.com/1080p60/index-dvr.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=3000000,CODECS="avc1.640020,mp4a.40.2",RESOLUTION=1280x720,FRAME-RATE=59.940,AUDIO="audio"
+https://example.com/720p60/index-dvr.m3u8
+`
+
+	pl, err := DecodeMultivariant(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("DecodeMultivariant returned error: %v", err)
+	}
+
+	if len(pl.Variants) != 4 {
+		t.Fatalf("expected 4 variants, got %d", len(pl.Variants))
+	}
+
+	expected := []struct {
+		video string
+		uri   string
+	}{
+		{"360p30", "https://example.com/360p30/index-dvr.m3u8"},
+		{"audio_only", "https://example.com/audio_only/index-dvr.m3u8"},
+		{"1080p60", "https://example.com/1080p60/index-dvr.m3u8"},
+		{"720p60", "https://example.com/720p60/index-dvr.m3u8"},
+	}
+
+	for i, exp := range expected {
+		if pl.Variants[i].Video != exp.video {
+			t.Fatalf("variant %d expected video %q, got %q", i, exp.video, pl.Variants[i].Video)
+		}
+		if pl.Variants[i].URI != exp.uri {
+			t.Fatalf("variant %d expected URI %q, got %q", i, exp.uri, pl.Variants[i].URI)
+		}
+	}
+}
+
+func TestDecodeMultivariantDoesNotOverwriteExistingVideo(t *testing.T) {
+	input := `#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=6000000,CODECS="avc1.64002a,mp4a.40.2",RESOLUTION=1920x1080,FRAME-RATE=60.000,VIDEO="chunked",STABLE-VARIANT-ID="1080p60",IVS-NAME="source",AUDIO="audio"
+https://example.com/source/index-dvr.m3u8
+`
+
+	pl, err := DecodeMultivariant(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("DecodeMultivariant returned error: %v", err)
+	}
+
+	if len(pl.Variants) != 1 {
+		t.Fatalf("expected 1 variant, got %d", len(pl.Variants))
+	}
+	if pl.Variants[0].Video != "chunked" {
+		t.Fatalf("expected existing VIDEO to be preserved, got %q", pl.Variants[0].Video)
+	}
+}

--- a/internal/live/live_test.go
+++ b/internal/live/live_test.go
@@ -17,6 +17,7 @@ import (
 	entVod "github.com/zibbp/ganymede/ent/vod"
 	"github.com/zibbp/ganymede/internal/archive"
 	"github.com/zibbp/ganymede/internal/config"
+	internalExec "github.com/zibbp/ganymede/internal/exec"
 	"github.com/zibbp/ganymede/internal/live"
 	"github.com/zibbp/ganymede/internal/platform"
 	"github.com/zibbp/ganymede/internal/server"
@@ -238,6 +239,86 @@ func assertVodAndQueue(t *testing.T, app *server.Application, liveChannel platfo
 
 }
 
+func assertAudioOnlyFile(t *testing.T, path string) {
+	t.Helper()
+
+	probeData, err := internalExec.GetFfprobeVideoData(t.Context(), path)
+	assert.NoError(t, err, "Failed to probe archived media")
+	assert.NotNil(t, probeData, "Expected ffprobe data for archived media")
+
+	audioStreams := 0
+	videoStreams := 0
+	for _, stream := range probeData.Streams {
+		switch stream.CodecType {
+		case "audio":
+			audioStreams++
+		case "video":
+			videoStreams++
+		}
+	}
+
+	assert.Greater(t, audioStreams, 0, "Archived media should contain at least one audio stream")
+	assert.Zero(t, videoStreams, "Archived media should not contain video streams")
+}
+
+func assertAudioOnlyVodAndQueue(t *testing.T, app *server.Application, liveChannel platform.LiveStreamInfo) {
+	vod, err := app.Database.Client.Vod.Query().Where(entVod.ExtStreamID(liveChannel.ID)).WithChannel().WithChapters().First(t.Context())
+	assert.NoError(t, err, "Failed to query VOD for live stream")
+	assert.NotNil(t, vod, "VOD should not be nil")
+
+	q, err := app.Database.Client.Queue.Query().Where(queue.HasVodWith(entVod.ID(vod.ID))).Only(t.Context())
+	assert.NoError(t, err, "Failed to query queue item for VOD")
+	assert.NotNil(t, q, "Queue item for VOD should not be nil")
+
+	t.Logf("Waiting for audio-only live stream to archive")
+	time.Sleep(60 * time.Second)
+
+	assert.NoError(t, app.QueueService.StopQueueItem(t.Context(), q.ID), "Failed to stop live archive")
+	tests_shared.WaitForArchiveCompletion(t, app, vod.ID, TestArchiveTimeout)
+
+	vod, err = app.Database.Client.Vod.Query().Where(entVod.ExtStreamID(liveChannel.ID)).WithChannel().WithChapters().First(t.Context())
+	assert.NoError(t, err, "Failed to query VOD for live stream")
+	assert.NotNil(t, vod, "VOD should not be nil")
+
+	q, err = app.Database.Client.Queue.Get(t.Context(), q.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, q)
+	assert.Equal(t, true, q.LiveArchive)
+	assert.Equal(t, false, q.ArchiveChat)
+	assert.Equal(t, false, q.RenderChat)
+	assert.Equal(t, false, q.ChatProcessing)
+	assert.Equal(t, false, q.VideoProcessing)
+	assert.Equal(t, utils.Success, q.TaskChatDownload)
+	assert.Equal(t, utils.Success, q.TaskChatConvert)
+	assert.Equal(t, utils.Success, q.TaskChatRender)
+	assert.Equal(t, utils.Success, q.TaskChatMove)
+	assert.Equal(t, utils.Success, q.TaskVideoDownload)
+	assert.Equal(t, utils.Success, q.TaskVideoConvert)
+	assert.Equal(t, utils.Success, q.TaskVideoMove)
+
+	assert.FileExists(t, vod.ThumbnailPath)
+	assert.FileExists(t, vod.WebThumbnailPath)
+	assert.FileExists(t, vod.VideoPath)
+	assert.Empty(t, vod.ChatPath)
+	assert.Empty(t, vod.ChatVideoPath)
+	assert.NotEqual(t, 0, vod.StorageSizeBytes)
+	assertAudioOnlyFile(t, vod.VideoPath)
+
+	assert.NotEmpty(t, vod.Edges.Chapters, "Expected at least one chapter to be present")
+
+	infoFileInfo, err := os.Stat(vod.InfoPath)
+	assert.NoError(t, err)
+	assert.Greater(t, infoFileInfo.Size(), int64(0), "Info file should not be empty")
+
+	thumbnailFileInfo, err := os.Stat(vod.ThumbnailPath)
+	assert.NoError(t, err)
+	assert.Greater(t, thumbnailFileInfo.Size(), int64(0), "Thumbnail file should not be empty")
+
+	webThumbnailFileInfo, err := os.Stat(vod.WebThumbnailPath)
+	assert.NoError(t, err)
+	assert.Greater(t, webThumbnailFileInfo.Size(), int64(0), "Web thumbnail file should not be empty")
+}
+
 // Helper to assert no VOD and queue item exist
 func assertNoVodAndQueue(t *testing.T, app *server.Application, liveChannel platform.LiveStreamInfo) {
 	vod, err := app.Database.Client.Vod.Query().Where(entVod.ExtStreamID(liveChannel.ID)).Only(t.Context())
@@ -268,6 +349,27 @@ func TestTwitchWatchedChannelLive(t *testing.T) {
 	watchedChannel := createWatchedChannel(t, app, liveInput, channel.ID, nil, nil)
 	startAndWaitForArchiving(t, app, watchedChannel.ID, false)
 	assertVodAndQueue(t, app, liveChannel, true)
+}
+
+// TestTwitchWatchedChannelLiveAudioOnlyNoChat tests live archiving audio only without chat.
+func TestTwitchWatchedChannelLiveAudioOnlyNoChat(t *testing.T) {
+	app, liveChannel, channel := setupAppAndLiveChannel(t)
+	liveInput := live.Live{
+		ID:                    channel.ID,
+		WatchLive:             true,
+		WatchVod:              false,
+		DownloadArchives:      false,
+		DownloadHighlights:    false,
+		DownloadUploads:       false,
+		ArchiveChat:           false,
+		Resolution:            "audio",
+		RenderChat:            false,
+		DownloadSubOnly:       false,
+		UpdateMetadataMinutes: 1,
+	}
+	watchedChannel := createWatchedChannel(t, app, liveInput, channel.ID, nil, nil)
+	startAndWaitForArchiving(t, app, watchedChannel.ID, false)
+	assertAudioOnlyVodAndQueue(t, app, liveChannel)
 }
 
 // TestTwitchWatchedChannelLiveFFmpegKilledStillFinalizes verifies that if ffmpeg dies during live recording,

--- a/internal/platform/twitch.go
+++ b/internal/platform/twitch.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafov/m3u8"
 	"github.com/rs/zerolog/log"
 	"github.com/zibbp/ganymede/internal/chapter"
 	"github.com/zibbp/ganymede/internal/config"
 	"github.com/zibbp/ganymede/internal/dto"
+	"github.com/zibbp/ganymede/internal/hls"
 	"github.com/zibbp/ganymede/internal/utils"
 )
 
@@ -838,7 +838,7 @@ func (c *TwitchConnection) CheckIfStreamIsLive(ctx context.Context, channelName 
 }
 
 // GetStream fetches the m3u8 playlist for a live Twitch stream.
-func (c *TwitchConnection) GetStream(ctx context.Context, channelName string) (*m3u8.MasterPlaylist, error) {
+func (c *TwitchConnection) GetStream(ctx context.Context, channelName string) (*hls.Multivariant, error) {
 	token, err := c.TwitchGQLGetPlaybackAccessToken(channelName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get playback access token: %v", err)
@@ -895,14 +895,9 @@ func (c *TwitchConnection) GetStream(ctx context.Context, channelName string) (*
 		return nil, fmt.Errorf("received unexpected status code: %d", resp.StatusCode)
 	}
 
-	playlist, _, err := m3u8.DecodeFrom(resp.Body, false)
+	masterPlaylist, err := hls.DecodeMultivariant(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding m3u8 response body: %v", err)
-	}
-
-	masterPlaylist, ok := playlist.(*m3u8.MasterPlaylist)
-	if !ok {
-		return nil, fmt.Errorf("failed to cast playlist to a master playlist: %v", err)
 	}
 
 	return masterPlaylist, nil


### PR DESCRIPTION
1. replace deprecated hls library with a supported one
2. abstract parsing logic to separate package
3. fix hls playlist parsing logic for a specific proxy server
   1. This proxy server no longer returns the video quality in the `VIDEO` attribute