### PR TITLE
update yt-dlp to prefer ffmpeg for vod downloads

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -58,6 +58,29 @@ func appendFFmpegLiveOutputStreamArgs(args []string, audioOnly bool) []string {
 	)
 }
 
+func appendYtDlpVideoConfigArgs(args []string, configArgs string) []string {
+	skipValue := false
+	for _, arg := range strings.Split(configArgs, ",") {
+		trimmedArg := strings.TrimSpace(arg)
+		if skipValue {
+			skipValue = false
+			continue
+		}
+		if trimmedArg == "-o" || trimmedArg == "--output" || trimmedArg == "-P" || trimmedArg == "--paths" {
+			skipValue = true
+			continue
+		}
+		if strings.HasPrefix(trimmedArg, "--output=") || strings.HasPrefix(trimmedArg, "--paths=") ||
+			(len(trimmedArg) > 2 && (strings.HasPrefix(trimmedArg, "-o") || strings.HasPrefix(trimmedArg, "-P"))) {
+			continue
+		}
+		if trimmedArg != "" {
+			args = append(args, trimmedArg)
+		}
+	}
+	return args
+}
+
 func twitchVideoDownloadArgs(quality, url, outputPath, configArgs string) []string {
 	args := []string{
 		"-f", quality,
@@ -72,14 +95,9 @@ func twitchVideoDownloadArgs(quality, url, outputPath, configArgs string) []stri
 	}
 
 	// User arguments are intentionally last so an explicit downloader preference
-	// in the configuration can override the default.
-	for _, arg := range strings.Split(configArgs, ",") {
-		if strings.TrimSpace(arg) != "" {
-			args = append(args, arg)
-		}
-	}
-
-	return args
+	// in the configuration can override the default. Output options are excluded
+	// so the application-owned temporary path remains authoritative.
+	return appendYtDlpVideoConfigArgs(args, configArgs)
 }
 
 // DownloadTwitchVideo downloads a Twitch video.

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -58,6 +58,30 @@ func appendFFmpegLiveOutputStreamArgs(args []string, audioOnly bool) []string {
 	)
 }
 
+func twitchVideoDownloadArgs(quality, url, outputPath, configArgs string) []string {
+	args := []string{
+		"-f", quality,
+		url,
+		"-o", outputPath,
+		"--merge-output-format", "mp4", "--no-part",
+		"--no-warnings", "--progress", "--newline", "--no-check-certificate",
+		// Twitch VOD playlists can change their fMP4 initialization segment after a
+		// discontinuity. The native HLS downloader rejects a second EXT-X-MAP, while
+		// ffmpeg handles the new initialization section correctly.
+		"--hls-prefer-ffmpeg",
+	}
+
+	// User arguments are intentionally last so an explicit downloader preference
+	// in the configuration can override the default.
+	for _, arg := range strings.Split(configArgs, ",") {
+		if strings.TrimSpace(arg) != "" {
+			args = append(args, arg)
+		}
+	}
+
+	return args
+}
+
 // DownloadTwitchVideo downloads a Twitch video.
 func DownloadTwitchVideo(ctx context.Context, video ent.Vod) error {
 	// Get video channel
@@ -115,25 +139,12 @@ func DownloadTwitchVideo(ctx context.Context, video ent.Vod) error {
 	tmpVideoDownloadExt := filepath.Ext(video.TmpVideoDownloadPath)
 	tmpVideoDownloadPathNoExt := strings.TrimSuffix(video.TmpVideoDownloadPath, tmpVideoDownloadExt)
 
-	// Get user arguments from config
-	configYtDlpArgs := config.Get().Parameters.YtDlpVideo
-	configYtDlpArgsArr := strings.Split(configYtDlpArgs, ",")
-
-	var cmdArgs []string
-	cmdArgs = append(cmdArgs,
-		"-f", qualityString,
+	cmdArgs := twitchVideoDownloadArgs(
+		qualityString,
 		url,
-		"-o", fmt.Sprintf("%s.%%(ext)s", tmpVideoDownloadPathNoExt),
-		"--merge-output-format", "mp4", "--no-part",
-		"--no-warnings", "--progress", "--newline", "--no-check-certificate",
+		fmt.Sprintf("%s.%%(ext)s", tmpVideoDownloadPathNoExt),
+		config.Get().Parameters.YtDlpVideo,
 	)
-
-	// Sanitize config args before appending
-	for _, arg := range configYtDlpArgsArr {
-		if strings.TrimSpace(arg) != "" {
-			cmdArgs = append(cmdArgs, arg)
-		}
-	}
 
 	// Create yt-dlp command
 	cmd, cookieFile, err := ytdlpSvc.CreateCommand(ctx, cmdArgs, true)

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -91,6 +91,36 @@ func TestTwitchVideoDownloadArgsPreferFFmpegForHLS(t *testing.T) {
 	}
 }
 
+func TestAppendYtDlpVideoConfigArgsExcludesOutputOptions(t *testing.T) {
+	t.Parallel()
+
+	initial := []string{"-o", "/data/temp/video.%(ext)s"}
+	configArgs := strings.Join([]string{
+		"  --retries  ", "  10 ", "  ",
+		"-o", "/tmp/short-separated",
+		"--output", "/tmp/long-separated",
+		"-o=/tmp/short-equals",
+		"-o/tmp/short-attached",
+		"--output=/tmp/long-equals",
+		"-P", "/tmp/path-short-separated",
+		"--paths", "/tmp/path-long-separated",
+		"-P=/tmp/path-short-equals",
+		"-P/tmp/path-short-attached",
+		"--paths=/tmp/path-long-equals",
+		" --fragment-retries", "20 ",
+	}, ",")
+
+	got := appendYtDlpVideoConfigArgs(initial, configArgs)
+	want := []string{
+		"-o", "/data/temp/video.%(ext)s",
+		"--retries", "10",
+		"--fragment-retries", "20",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("appendYtDlpVideoConfigArgs() = %v, want %v", got, want)
+	}
+}
+
 func TestPostProcessVideoFFmpegArgsIncludesTitleMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -62,6 +62,35 @@ func TestVodArchiveProcessAttributes(t *testing.T) {
 	}
 }
 
+func TestTwitchVideoDownloadArgsPreferFFmpegForHLS(t *testing.T) {
+	t.Parallel()
+
+	args := twitchVideoDownloadArgs(
+		"best[height=1080]/best",
+		"https://twitch.tv/videos/2838897713",
+		"/tmp/video.%(ext)s",
+		"--fragment-retries,20",
+	)
+
+	ffmpegPreference := -1
+	customArgs := -1
+	for i, arg := range args {
+		switch arg {
+		case "--hls-prefer-ffmpeg":
+			ffmpegPreference = i
+		case "--fragment-retries":
+			customArgs = i
+		}
+	}
+
+	if ffmpegPreference == -1 {
+		t.Fatalf("Twitch VOD arguments do not prefer the ffmpeg HLS downloader: %v", args)
+	}
+	if customArgs == -1 || customArgs < ffmpegPreference {
+		t.Fatalf("configured yt-dlp arguments must follow defaults: %v", args)
+	}
+}
+
 func TestPostProcessVideoFFmpegArgsIncludesTitleMetadata(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
  - Prefer FFmpeg for Twitch HLS/VOD downloads to handle playlist discontinuities reliably.
  - Preserve configured yt-dlp options while preventing them from overriding the application’s temporary output path.